### PR TITLE
Feature/remove_from_federation

### DIFF
--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -15,6 +15,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/datastores/{datastoreId}  </sub>                                                   |DELETE    |
 |     **Hosts**
 |<sub>/hosts	</sub>                                                                    |GET       |
+|<sub>/hosts/{hostId}/remove_from_federation  </sub>						|POST      |
 |     **OmniStack Clusters**
 |<sub>/omnistack_clusters	</sub>                                                        |GET       |
 |     **Policies**

--- a/simplivity/resources/backups.py
+++ b/simplivity/resources/backups.py
@@ -30,6 +30,7 @@ class Backups(ResourceBase):
                 sort=None, order='descending', filters=None, fields=None,
                 case_sensitive=True):
         """Gets all backups.
+
         Args:
             pagination: True if need pagination
             page_size: Size of the page (Required when pagination is on)
@@ -126,6 +127,7 @@ class Backups(ResourceBase):
 
     def delete_multiple_backups(self, backups, timeout=-1):
         """Deletes a list of backups.
+
         Args:
           backups: list of backup objects
         """

--- a/simplivity/resources/hosts.py
+++ b/simplivity/resources/hosts.py
@@ -151,3 +151,22 @@ class Host(object):
         self.data = data
         self._connection = connection
         self._client = resource_client
+        self._hosts = Hosts(self._connection)
+
+    def remove(self, force=False, timeout=-1):
+        """Removes the specified host from the federation.
+
+        Args:
+          force: An indicator that specifies if the host should be removed forcefully or not.
+            Valid values:
+              True: Forces the removal of the host even if active virtual machines are
+                    present and if the host is not HA-compliant. This may cause data loss.
+              False: Returns an error if there are any virtual machines on the host or if the host is not HA-compliant.
+        """
+        http_headers = {"Content-type": 'application/vnd.simplivity.v1.9+json'}
+
+        method_url = "{}/{}/remove_from_federation".format(URL, self.data["id"])
+        data = {"force": force}
+
+        self._client.do_post(method_url, data, timeout, http_headers)
+        self.data = None

--- a/tests/unit/resources/test_hosts.py
+++ b/tests/unit/resources/test_hosts.py
@@ -90,6 +90,38 @@ class HostsTest(unittest.TestCase):
         self.assertIsInstance(obj, hosts.Host)
         self.assertEqual(obj.data, resource_data)
 
+    @mock.patch.object(Connection, "post")
+    def test_remove(self, mock_post):
+        mock_post.return_value = None, [{"object_id": "12345"}]
+
+        host_data = {"id": "12345"}
+        host = self.hosts.get_by_data(host_data)
+
+        host.remove()
+        self.assertEqual(host.data, None)
+
+        mock_post.assert_called_once_with(
+            "/hosts/12345/remove_from_federation",
+            {"force": False},
+            custom_headers={"Content-type": "application/vnd.simplivity.v1.9+json"},
+        )
+
+    @mock.patch.object(Connection, "post")
+    def test_remove_with_force(self, mock_post):
+        mock_post.return_value = None, [{"object_id": "12345"}]
+
+        host_data = {"id": "12345"}
+        host = self.hosts.get_by_data(host_data)
+
+        host.remove(force=True)
+        self.assertEqual(host.data, None)
+
+        mock_post.assert_called_once_with(
+            "/hosts/12345/remove_from_federation",
+            {"force": True},
+            custom_headers={"Content-type": "application/vnd.simplivity.v1.9+json"},
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
implement basic functionality for the remov_ from_federation rest endpoint.

opened ended questions
*    should the code call an exception if the host management_ip matches the connection ip address, or should we let the default exception bubble up?

*     remove_from_federation requires application/vnd.simplivity.v1.9+json however, the default that is used in the connection.py is application/vnd.simplivity.v1.8+json
- should I change the connection.py to use application/vnd.simplivity.v1.9+json, or 
- use a custom header to update the connect type to application/vnd.simplivity.v1.9+json
