### PR TITLE
remove external test dependencies for mock

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,4 @@
 coverage
 coveralls
 flake8
-mock
 pytest
-six

--- a/tests/unit/resources/test_backups.py
+++ b/tests/unit/resources/test_backups.py
@@ -15,7 +15,7 @@
 ##
 
 import unittest
-import mock
+from unittest import mock
 
 from simplivity.connection import Connection
 from simplivity import exceptions

--- a/tests/unit/resources/test_datastores.py
+++ b/tests/unit/resources/test_datastores.py
@@ -15,7 +15,7 @@
 ##
 
 import unittest
-import mock
+from unittest import mock
 
 from simplivity.connection import Connection
 from simplivity import exceptions

--- a/tests/unit/resources/test_hosts.py
+++ b/tests/unit/resources/test_hosts.py
@@ -15,7 +15,7 @@
 ##
 
 import unittest
-import mock
+from unittest import mock
 
 from simplivity.connection import Connection
 from simplivity import exceptions

--- a/tests/unit/resources/test_omnistack_clusters.py
+++ b/tests/unit/resources/test_omnistack_clusters.py
@@ -15,7 +15,7 @@
 ##
 
 import unittest
-import mock
+from unittest import mock
 
 from simplivity.connection import Connection
 from simplivity import exceptions

--- a/tests/unit/resources/test_policies.py
+++ b/tests/unit/resources/test_policies.py
@@ -15,7 +15,7 @@
 ##
 
 import unittest
-import mock
+from unittest import mock
 
 from simplivity.connection import Connection
 from simplivity import exceptions

--- a/tests/unit/resources/test_resource.py
+++ b/tests/unit/resources/test_resource.py
@@ -15,7 +15,7 @@
 ##
 
 import unittest
-import mock
+from unittest import mock
 
 from simplivity.connection import Connection
 from simplivity import exceptions

--- a/tests/unit/resources/test_tasks.py
+++ b/tests/unit/resources/test_tasks.py
@@ -15,7 +15,8 @@
 ##
 
 import unittest
-from mock import mock, call
+from unittest import mock
+from unittest.mock import call
 
 from simplivity.connection import Connection
 from simplivity.resources.tasks import Task

--- a/tests/unit/resources/test_virtual_machines.py
+++ b/tests/unit/resources/test_virtual_machines.py
@@ -15,8 +15,8 @@
 ##
 
 import unittest
-import mock
-from mock import call
+from unittest import mock
+from unittest.mock import call
 
 from simplivity.connection import Connection
 from simplivity import exceptions

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -1,5 +1,5 @@
 ###
-# (C) Copyright [2019] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2019-2020] Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@
 import json
 import ssl
 import unittest
+from http.client import HTTPException, HTTPSConnection
+from unittest.mock import ANY, Mock, call, patch
 
-from mock import patch, call, Mock, ANY
-from http.client import HTTPSConnection, HTTPException
 from simplivity.connection import Connection
 from simplivity.exceptions import HPESimpliVityException
 

--- a/tests/unit/test_ovc_client.py
+++ b/tests/unit/test_ovc_client.py
@@ -1,5 +1,5 @@
 ###
-# (C) Copyright [2019] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2019-2020] Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +15,10 @@
 ##
 
 import io
-import unittest
-import mock
 import sys
+import unittest
+from unittest import mock
+
 
 from simplivity.connection import Connection
 from simplivity.ovc_client import OVC


### PR DESCRIPTION
Since the tox unit test(s) run only against 3.4 and 3.6, we should use the unittest.mock core module instead of the external package mock that was intended for python versions before version 3.3

https://docs.python.org/3/library/unittest.mock.html

Unittest.mock provides a core Mock class removing the need to create a host of stubs throughout your test suite. After performing an action, you can make assertions about which methods / attributes were used and arguments they were called with. You can also specify return values and set needed attributes in the normal way.

