### PR TITLE
Add support for query param in POST operations

### DIFF
--- a/simplivity/resources/resource.py
+++ b/simplivity/resources/resource.py
@@ -223,18 +223,22 @@ class ResourceClient(object):
         """
         return self._connection.get(uri)
 
-    def do_post(self, uri, data, timeout, custom_headers):
+    def do_post(self, uri, data, timeout, custom_headers, flags=None):
         """Makes post requests.
 
         Args:
             uri: URI of the resource.
             data: Request body of the call
             timeout: Time out for the request in seconds.
-            cutom_headers: Allows to add custom http headers.
+            flags: Dictionary of filters, example: {'name': 'name'}
+            custom_headers: Allows to add custom http headers.
 
         Returns:
             list: Returns ids of the affected resources.
         """
+        if flags and isinstance(flags, dict):
+            uri = build_uri_with_query_string(uri, flags)
+
         task, entity = self._connection.post(uri, data, custom_headers=custom_headers)
 
         if not task:

--- a/tests/unit/resources/test_resource.py
+++ b/tests/unit/resources/test_resource.py
@@ -100,6 +100,17 @@ class ResourceTest(unittest.TestCase):
         mock_post.assert_called_once_with(url, data, custom_headers=None)
 
     @mock.patch.object(Connection, "post")
+    def test_post_call_filters(self, mock_post):
+        url = "/api/resource"
+        data = {"name": "name"}
+
+        mock_post.return_value = None, {}
+        flags = {'cluster_id': 'ASFADF'}
+        self.resource_client.do_post(url, data, -1, None, flags)
+        expected_url = "/api/resource?cluster_id=ASFADF"
+        mock_post.assert_called_once_with(expected_url, data, custom_headers=None)
+
+    @mock.patch.object(Connection, "post")
     @mock.patch.object(Connection, "get")
     def test_post_call_with_task(self, mock_get, mock_post):
         url = "/api/resource"


### PR DESCRIPTION
Signed-off-by: Hemant Chaudhari <hchaudhari@hpe.com>

SimpliVity requires the query parameters support in the POST request. This is required to implement policy and policy rule create.
