### PR TITLE
resolve unit test file naming issue

### DIFF
--- a/tests/unit/resources/test_datastores.py
+++ b/tests/unit/resources/test_datastores.py
@@ -20,76 +20,74 @@ from unittest import mock
 from simplivity.connection import Connection
 from simplivity import exceptions
 from simplivity.resources import datastores
-from simplivity.resources import omnistack_clusters as clusters
 
 
-class OmnistackClustersTest(unittest.TestCase):
+class DatastoresTest(unittest.TestCase):
     def setUp(self):
         self.connection = Connection('127.0.0.1')
         self.connection._access_token = "123456789"
-        self.clusters = clusters.OmnistackClusters(self.connection)
         self.datastores = datastores.Datastores(self.connection)
 
     @mock.patch.object(Connection, "get")
     def test_get_all_returns_resource_obj(self, mock_get):
-        url = "{}?case=sensitive&limit=500&offset=0&order=descending&sort=name".format(clusters.URL)
+        url = "{}?case=sensitive&limit=500&offset=0&order=descending&sort=name".format(datastores.URL)
         resource_data = [{'id': '12345'}, {'id': '67890'}]
-        mock_get.return_value = {clusters.DATA_FIELD: resource_data}
+        mock_get.return_value = {datastores.DATA_FIELD: resource_data}
 
-        objs = self.clusters.get_all()
-        self.assertIsInstance(objs[0], clusters.OmnistackCluster)
+        objs = self.datastores.get_all()
+        self.assertIsInstance(objs[0], datastores.Datastore)
         self.assertEqual(objs[0].data, resource_data[0])
         mock_get.assert_called_once_with(url)
 
     @mock.patch.object(Connection, "get")
     def test_get_by_name_found(self, mock_get):
         name = "testname"
-        url = "{}?case=sensitive&limit=500&name={}&offset=0&order=descending&sort=name".format(clusters.URL, name)
+        url = "{}?case=sensitive&limit=500&name={}&offset=0&order=descending&sort=name".format(datastores.URL, name)
         resource_data = [{'id': '12345', 'name': name}]
-        mock_get.return_value = {clusters.DATA_FIELD: resource_data}
+        mock_get.return_value = {datastores.DATA_FIELD: resource_data}
 
-        obj = self.clusters.get_by_name(name)
-        self.assertIsInstance(obj, clusters.OmnistackCluster)
+        obj = self.datastores.get_by_name(name)
+        self.assertIsInstance(obj, datastores.Datastore)
         mock_get.assert_called_once_with(url)
 
     @mock.patch.object(Connection, "get")
     def test_get_by_name_not_found(self, mock_get):
         name = "testname"
         resource_data = []
-        mock_get.return_value = {clusters.DATA_FIELD: resource_data}
+        mock_get.return_value = {datastores.DATA_FIELD: resource_data}
 
         with self.assertRaises(exceptions.HPESimpliVityResourceNotFound) as error:
-            self.clusters.get_by_name(name)
+            self.datastores.get_by_name(name)
 
         self.assertEqual(error.exception.msg, "Resource not found with the name {}".format(name))
 
     @mock.patch.object(Connection, "get")
     def test_get_by_id_found(self, mock_get):
         resource_id = "12345"
-        url = "{}?case=sensitive&id={}&limit=500&offset=0&order=descending&sort=name".format(clusters.URL, resource_id)
+        url = "{}?case=sensitive&id={}&limit=500&offset=0&order=descending&sort=name".format(datastores.URL, resource_id)
         resource_data = [{'id': resource_id}]
-        mock_get.return_value = {clusters.DATA_FIELD: resource_data}
+        mock_get.return_value = {datastores.DATA_FIELD: resource_data}
 
-        obj = self.clusters.get_by_id(resource_id)
-        self.assertIsInstance(obj, clusters.OmnistackCluster)
+        obj = self.datastores.get_by_id(resource_id)
+        self.assertIsInstance(obj, datastores.Datastore)
         mock_get.assert_called_once_with(url)
 
     @mock.patch.object(Connection, "get")
     def test_get_by_id_not_found(self, mock_get):
         resource_id = "12345"
         resource_data = []
-        mock_get.return_value = {clusters.DATA_FIELD: resource_data}
+        mock_get.return_value = {datastores.DATA_FIELD: resource_data}
 
         with self.assertRaises(exceptions.HPESimpliVityResourceNotFound) as error:
-            self.clusters.get_by_id(resource_id)
+            self.datastores.get_by_id(resource_id)
 
         self.assertEqual(error.exception.msg, "Resource not found with the id {}".format(resource_id))
 
     def test_get_by_data(self):
         resource_data = {'id': '12345'}
 
-        obj = self.clusters.get_by_data(resource_data)
-        self.assertIsInstance(obj, clusters.OmnistackCluster)
+        obj = self.datastores.get_by_data(resource_data)
+        self.assertIsInstance(obj, datastores.Datastore)
         self.assertEqual(obj.data, resource_data)
 
     @mock.patch.object(Connection, "delete")

--- a/tests/unit/resources/test_omnistack_clusters.py
+++ b/tests/unit/resources/test_omnistack_clusters.py
@@ -19,75 +19,75 @@ from unittest import mock
 
 from simplivity.connection import Connection
 from simplivity import exceptions
-from simplivity.resources import datastores
+from simplivity.resources import omnistack_clusters as clusters
 
 
-class DatastoresTest(unittest.TestCase):
+class OmnistackClustersTest(unittest.TestCase):
     def setUp(self):
         self.connection = Connection('127.0.0.1')
         self.connection._access_token = "123456789"
-        self.datastores = datastores.Datastores(self.connection)
+        self.clusters = clusters.OmnistackClusters(self.connection)
 
     @mock.patch.object(Connection, "get")
     def test_get_all_returns_resource_obj(self, mock_get):
-        url = "{}?case=sensitive&limit=500&offset=0&order=descending&sort=name".format(datastores.URL)
+        url = "{}?case=sensitive&limit=500&offset=0&order=descending&sort=name".format(clusters.URL)
         resource_data = [{'id': '12345'}, {'id': '67890'}]
-        mock_get.return_value = {datastores.DATA_FIELD: resource_data}
+        mock_get.return_value = {clusters.DATA_FIELD: resource_data}
 
-        objs = self.datastores.get_all()
-        self.assertIsInstance(objs[0], datastores.Datastore)
+        objs = self.clusters.get_all()
+        self.assertIsInstance(objs[0], clusters.OmnistackCluster)
         self.assertEqual(objs[0].data, resource_data[0])
         mock_get.assert_called_once_with(url)
 
     @mock.patch.object(Connection, "get")
     def test_get_by_name_found(self, mock_get):
         name = "testname"
-        url = "{}?case=sensitive&limit=500&name={}&offset=0&order=descending&sort=name".format(datastores.URL, name)
+        url = "{}?case=sensitive&limit=500&name={}&offset=0&order=descending&sort=name".format(clusters.URL, name)
         resource_data = [{'id': '12345', 'name': name}]
-        mock_get.return_value = {datastores.DATA_FIELD: resource_data}
+        mock_get.return_value = {clusters.DATA_FIELD: resource_data}
 
-        obj = self.datastores.get_by_name(name)
-        self.assertIsInstance(obj, datastores.Datastore)
+        obj = self.clusters.get_by_name(name)
+        self.assertIsInstance(obj, clusters.OmnistackCluster)
         mock_get.assert_called_once_with(url)
 
     @mock.patch.object(Connection, "get")
     def test_get_by_name_not_found(self, mock_get):
         name = "testname"
         resource_data = []
-        mock_get.return_value = {datastores.DATA_FIELD: resource_data}
+        mock_get.return_value = {clusters.DATA_FIELD: resource_data}
 
         with self.assertRaises(exceptions.HPESimpliVityResourceNotFound) as error:
-            self.datastores.get_by_name(name)
+            self.clusters.get_by_name(name)
 
         self.assertEqual(error.exception.msg, "Resource not found with the name {}".format(name))
 
     @mock.patch.object(Connection, "get")
     def test_get_by_id_found(self, mock_get):
         resource_id = "12345"
-        url = "{}?case=sensitive&id={}&limit=500&offset=0&order=descending&sort=name".format(datastores.URL, resource_id)
+        url = "{}?case=sensitive&id={}&limit=500&offset=0&order=descending&sort=name".format(clusters.URL, resource_id)
         resource_data = [{'id': resource_id}]
-        mock_get.return_value = {datastores.DATA_FIELD: resource_data}
+        mock_get.return_value = {clusters.DATA_FIELD: resource_data}
 
-        obj = self.datastores.get_by_id(resource_id)
-        self.assertIsInstance(obj, datastores.Datastore)
+        obj = self.clusters.get_by_id(resource_id)
+        self.assertIsInstance(obj, clusters.OmnistackCluster)
         mock_get.assert_called_once_with(url)
 
     @mock.patch.object(Connection, "get")
     def test_get_by_id_not_found(self, mock_get):
         resource_id = "12345"
         resource_data = []
-        mock_get.return_value = {datastores.DATA_FIELD: resource_data}
+        mock_get.return_value = {clusters.DATA_FIELD: resource_data}
 
         with self.assertRaises(exceptions.HPESimpliVityResourceNotFound) as error:
-            self.datastores.get_by_id(resource_id)
+            self.clusters.get_by_id(resource_id)
 
         self.assertEqual(error.exception.msg, "Resource not found with the id {}".format(resource_id))
 
     def test_get_by_data(self):
         resource_data = {'id': '12345'}
 
-        obj = self.datastores.get_by_data(resource_data)
-        self.assertIsInstance(obj, datastores.Datastore)
+        obj = self.clusters.get_by_data(resource_data)
+        self.assertIsInstance(obj, clusters.OmnistackCluster)
         self.assertEqual(obj.data, resource_data)
 
 


### PR DESCRIPTION
Discovered that the unit tests within test_datastores.py were for the omnistack cluster objects, and the unit tests within test_omnistack_clusters.py were for the datastore objects.

The files were renamed, and then the test_delete, was moved to the correct file.

Signed-off-by: Ken McDaniel <kenneth.mcdaniel@hpe.com>