### PR TITLE
Add support for the create policy

### DIFF
--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -20,6 +20,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/omnistack_clusters	</sub>                                                        |GET       |
 |     **Policies**
 |<sub>/policies	</sub>                                                                    |GET       |
+|<sub>/policies</sub>                                                                     |POST
 |<sub>/policies/{policyId} </sub>                                                         |DELETE    |
 |     **Virtual Machines**
 |<sub>/virtual_machines	</sub>                                                            |GET       |

--- a/examples/policies.py
+++ b/examples/policies.py
@@ -18,10 +18,10 @@ from simplivity.ovc_client import OVC
 from simplivity.exceptions import HPESimpliVityException
 
 config = {
-    "ip": "<ovc_ip>",
+    "ip": "10.148.1.209",
     "credentials": {
-        "username": "<username>",
-        "password": "<password>"
+        "username": "administrator@vsphere.local",
+        "password": "svtrfs29L@B"
     }
 }
 
@@ -70,3 +70,12 @@ print("\n\n get_all VMs using this policy")
 vms = policy.get_vms()
 print(policy.data)
 print(vms)
+
+print("\n\n create policy")
+policy_name = "test_policy12"
+response_policies = policies.create(policy_name)
+policy = response_policies[0]
+print(policy, policy.data)
+
+print("\n\n delete policy")
+policy.delete()

--- a/simplivity/resources/policies.py
+++ b/simplivity/resources/policies.py
@@ -73,6 +73,23 @@ class Policies(ResourceBase):
         """
         return Policy(self._connection, self._client, data)
 
+    def create(self, name, flags=None, timeout=-1):
+        """ create the new policy
+
+        Args:
+            flags: Dictionary of filters, example: {'cluster_group_id': 'cluster_group_id'}
+            name : name of policy
+            timeout : timeout for the operation to complete
+
+        Returns:
+            Returns Policies object, list of policy which will always have single
+            policy created
+        """
+        data = {"name": name}
+        self._client.do_post(URL, data, timeout, None, flags)
+        policies = self.get_all(filters={'name': name})
+        return policies
+
 
 class Policy(object):
     """Implements features available for a single Policy resource."""

--- a/tests/unit/resources/test_datastores.py
+++ b/tests/unit/resources/test_datastores.py
@@ -20,76 +20,74 @@ from unittest import mock
 from simplivity.connection import Connection
 from simplivity import exceptions
 from simplivity.resources import datastores
-from simplivity.resources import omnistack_clusters as clusters
 
 
-class OmnistackClustersTest(unittest.TestCase):
+class DatastoresTest(unittest.TestCase):
     def setUp(self):
         self.connection = Connection('127.0.0.1')
         self.connection._access_token = "123456789"
-        self.clusters = clusters.OmnistackClusters(self.connection)
         self.datastores = datastores.Datastores(self.connection)
 
     @mock.patch.object(Connection, "get")
     def test_get_all_returns_resource_obj(self, mock_get):
-        url = "{}?case=sensitive&limit=500&offset=0&order=descending&sort=name".format(clusters.URL)
+        url = "{}?case=sensitive&limit=500&offset=0&order=descending&sort=name".format(datastores.URL)
         resource_data = [{'id': '12345'}, {'id': '67890'}]
-        mock_get.return_value = {clusters.DATA_FIELD: resource_data}
+        mock_get.return_value = {datastores.DATA_FIELD: resource_data}
 
-        objs = self.clusters.get_all()
-        self.assertIsInstance(objs[0], clusters.OmnistackCluster)
+        objs = self.datastores.get_all()
+        self.assertIsInstance(objs[0], datastores.Datastore)
         self.assertEqual(objs[0].data, resource_data[0])
         mock_get.assert_called_once_with(url)
 
     @mock.patch.object(Connection, "get")
     def test_get_by_name_found(self, mock_get):
         name = "testname"
-        url = "{}?case=sensitive&limit=500&name={}&offset=0&order=descending&sort=name".format(clusters.URL, name)
+        url = "{}?case=sensitive&limit=500&name={}&offset=0&order=descending&sort=name".format(datastores.URL, name)
         resource_data = [{'id': '12345', 'name': name}]
-        mock_get.return_value = {clusters.DATA_FIELD: resource_data}
+        mock_get.return_value = {datastores.DATA_FIELD: resource_data}
 
-        obj = self.clusters.get_by_name(name)
-        self.assertIsInstance(obj, clusters.OmnistackCluster)
+        obj = self.datastores.get_by_name(name)
+        self.assertIsInstance(obj, datastores.Datastore)
         mock_get.assert_called_once_with(url)
 
     @mock.patch.object(Connection, "get")
     def test_get_by_name_not_found(self, mock_get):
         name = "testname"
         resource_data = []
-        mock_get.return_value = {clusters.DATA_FIELD: resource_data}
+        mock_get.return_value = {datastores.DATA_FIELD: resource_data}
 
         with self.assertRaises(exceptions.HPESimpliVityResourceNotFound) as error:
-            self.clusters.get_by_name(name)
+            self.datastores.get_by_name(name)
 
         self.assertEqual(error.exception.msg, "Resource not found with the name {}".format(name))
 
     @mock.patch.object(Connection, "get")
     def test_get_by_id_found(self, mock_get):
         resource_id = "12345"
-        url = "{}?case=sensitive&id={}&limit=500&offset=0&order=descending&sort=name".format(clusters.URL, resource_id)
+        url = "{}?case=sensitive&id={}&limit=500&offset=0&order=descending&sort=name".format(datastores.URL, resource_id)
         resource_data = [{'id': resource_id}]
-        mock_get.return_value = {clusters.DATA_FIELD: resource_data}
+        mock_get.return_value = {datastores.DATA_FIELD: resource_data}
 
-        obj = self.clusters.get_by_id(resource_id)
-        self.assertIsInstance(obj, clusters.OmnistackCluster)
+        obj = self.datastores.get_by_id(resource_id)
+        self.assertIsInstance(obj, datastores.Datastore)
         mock_get.assert_called_once_with(url)
 
     @mock.patch.object(Connection, "get")
     def test_get_by_id_not_found(self, mock_get):
         resource_id = "12345"
         resource_data = []
-        mock_get.return_value = {clusters.DATA_FIELD: resource_data}
+        mock_get.return_value = {datastores.DATA_FIELD: resource_data}
 
         with self.assertRaises(exceptions.HPESimpliVityResourceNotFound) as error:
-            self.clusters.get_by_id(resource_id)
+            self.datastores.get_by_id(resource_id)
 
         self.assertEqual(error.exception.msg, "Resource not found with the id {}".format(resource_id))
 
     def test_get_by_data(self):
         resource_data = {'id': '12345'}
 
-        obj = self.clusters.get_by_data(resource_data)
-        self.assertIsInstance(obj, clusters.OmnistackCluster)
+        obj = self.datastores.get_by_data(resource_data)
+        self.assertIsInstance(obj, datastores.Datastore)
         self.assertEqual(obj.data, resource_data)
 
     @mock.patch.object(Connection, "delete")

--- a/tests/unit/resources/test_omnistack_clusters.py
+++ b/tests/unit/resources/test_omnistack_clusters.py
@@ -19,75 +19,75 @@ from unittest import mock
 
 from simplivity.connection import Connection
 from simplivity import exceptions
-from simplivity.resources import datastores
+from simplivity.resources import omnistack_clusters as clusters
 
 
-class DatastoresTest(unittest.TestCase):
+class OmnistackClustersTest(unittest.TestCase):
     def setUp(self):
         self.connection = Connection('127.0.0.1')
         self.connection._access_token = "123456789"
-        self.datastores = datastores.Datastores(self.connection)
+        self.clusters = clusters.OmnistackClusters(self.connection)
 
     @mock.patch.object(Connection, "get")
     def test_get_all_returns_resource_obj(self, mock_get):
-        url = "{}?case=sensitive&limit=500&offset=0&order=descending&sort=name".format(datastores.URL)
+        url = "{}?case=sensitive&limit=500&offset=0&order=descending&sort=name".format(clusters.URL)
         resource_data = [{'id': '12345'}, {'id': '67890'}]
-        mock_get.return_value = {datastores.DATA_FIELD: resource_data}
+        mock_get.return_value = {clusters.DATA_FIELD: resource_data}
 
-        objs = self.datastores.get_all()
-        self.assertIsInstance(objs[0], datastores.Datastore)
+        objs = self.clusters.get_all()
+        self.assertIsInstance(objs[0], clusters.OmnistackCluster)
         self.assertEqual(objs[0].data, resource_data[0])
         mock_get.assert_called_once_with(url)
 
     @mock.patch.object(Connection, "get")
     def test_get_by_name_found(self, mock_get):
         name = "testname"
-        url = "{}?case=sensitive&limit=500&name={}&offset=0&order=descending&sort=name".format(datastores.URL, name)
+        url = "{}?case=sensitive&limit=500&name={}&offset=0&order=descending&sort=name".format(clusters.URL, name)
         resource_data = [{'id': '12345', 'name': name}]
-        mock_get.return_value = {datastores.DATA_FIELD: resource_data}
+        mock_get.return_value = {clusters.DATA_FIELD: resource_data}
 
-        obj = self.datastores.get_by_name(name)
-        self.assertIsInstance(obj, datastores.Datastore)
+        obj = self.clusters.get_by_name(name)
+        self.assertIsInstance(obj, clusters.OmnistackCluster)
         mock_get.assert_called_once_with(url)
 
     @mock.patch.object(Connection, "get")
     def test_get_by_name_not_found(self, mock_get):
         name = "testname"
         resource_data = []
-        mock_get.return_value = {datastores.DATA_FIELD: resource_data}
+        mock_get.return_value = {clusters.DATA_FIELD: resource_data}
 
         with self.assertRaises(exceptions.HPESimpliVityResourceNotFound) as error:
-            self.datastores.get_by_name(name)
+            self.clusters.get_by_name(name)
 
         self.assertEqual(error.exception.msg, "Resource not found with the name {}".format(name))
 
     @mock.patch.object(Connection, "get")
     def test_get_by_id_found(self, mock_get):
         resource_id = "12345"
-        url = "{}?case=sensitive&id={}&limit=500&offset=0&order=descending&sort=name".format(datastores.URL, resource_id)
+        url = "{}?case=sensitive&id={}&limit=500&offset=0&order=descending&sort=name".format(clusters.URL, resource_id)
         resource_data = [{'id': resource_id}]
-        mock_get.return_value = {datastores.DATA_FIELD: resource_data}
+        mock_get.return_value = {clusters.DATA_FIELD: resource_data}
 
-        obj = self.datastores.get_by_id(resource_id)
-        self.assertIsInstance(obj, datastores.Datastore)
+        obj = self.clusters.get_by_id(resource_id)
+        self.assertIsInstance(obj, clusters.OmnistackCluster)
         mock_get.assert_called_once_with(url)
 
     @mock.patch.object(Connection, "get")
     def test_get_by_id_not_found(self, mock_get):
         resource_id = "12345"
         resource_data = []
-        mock_get.return_value = {datastores.DATA_FIELD: resource_data}
+        mock_get.return_value = {clusters.DATA_FIELD: resource_data}
 
         with self.assertRaises(exceptions.HPESimpliVityResourceNotFound) as error:
-            self.datastores.get_by_id(resource_id)
+            self.clusters.get_by_id(resource_id)
 
         self.assertEqual(error.exception.msg, "Resource not found with the id {}".format(resource_id))
 
     def test_get_by_data(self):
         resource_data = {'id': '12345'}
 
-        obj = self.datastores.get_by_data(resource_data)
-        self.assertIsInstance(obj, datastores.Datastore)
+        obj = self.clusters.get_by_data(resource_data)
+        self.assertIsInstance(obj, clusters.OmnistackCluster)
         self.assertEqual(obj.data, resource_data)
 
 

--- a/tests/unit/resources/test_policies.py
+++ b/tests/unit/resources/test_policies.py
@@ -141,6 +141,21 @@ class PoliciesTest(unittest.TestCase):
 
         mock_get.assert_called_once_with('/policies/ABCDE/virtual_machines')
 
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_create_policy(self, mock_post, mock_get):
+        resource_data = [{'name': 'test'}]
+        mock_post.return_value = {policies.DATA_FIELD: resource_data}
+        mock_get.return_value = None, [{'object_id': '12345'}]
+        policy_name = 'test'
+        response = self.policies.create(policy_name)
+        policy = response[0]
+
+        self.assertIsInstance(policy, policies.Policy)
+        self.assertEqual(policy.data, resource_data[0])
+        url = "{}?case=sensitive&limit=500&name={}&offset=0&order=descending&sort=name".format(policies.URL, policy_name)
+        mock_post.assert_called_once_with(url)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Comment 1**
svt-kmcdaniel 
should we use the return from policies.create to delete the policy?

That will ensure that we are deleting the policy that was created.

svt-hchaudhari 
Yes made the respective changes to get the list of policies and then retrieving the required policy object to delete the same.

**Comment 2**
svt-kmcdaniel 
should we use the return from policies.create to delete the policy?

That will ensure that we are deleting the policy that was created.
 
svt-hchaudhari 
Yes made the respective changes to get the list of policies and then retrieving the required policy object to delete the same.

**Comment 3**
svt-kmcdaniel 
need to ensure that policies.create() returns a Policy object within the unit tests

svt-hchaudhari 
Agreed, made the respective changes.