### PR TITLE
Add support for the create policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /datastore/{datastoreId} <DELETE>
     - endpoint support for /hosts/{hostId}/remove_from_federation <POST>    
     - endpoint support for /policies/{policyId} <DELETE>
+    - endpoint support for /policies <POST>
     - pull request template to facilitate pull requests
     - query string support for post operations
 

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -21,6 +21,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/omnistack_clusters	</sub>                                                        |GET       |
 |     **Policies**
 |<sub>/policies	</sub>                                                                    |GET       |
+|<sub>/policies</sub>                                                                     |POST      |
 |<sub>/policies/{policyId} </sub>                                                         |DELETE    |
 |     **Virtual Machines**
 |<sub>/virtual_machines	</sub>                                                            |GET       |

--- a/examples/policies.py
+++ b/examples/policies.py
@@ -1,5 +1,5 @@
 ###
-# (C) Copyright [2019] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2019-2020] Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,9 @@
 
 from simplivity.ovc_client import OVC
 from simplivity.exceptions import HPESimpliVityException
+import pprint
+
+pp = pprint.PrettyPrinter(indent=4)
 
 config = {
     "ip": "<ovc_ip>",
@@ -28,45 +31,61 @@ config = {
 ovc = OVC(config)
 policies = ovc.policies
 
-print("\n\n get_all with default params")
+print("\n\nget_all with default params")
 all_policies = policies.get_all()
 count = len(all_policies)
 for policy in all_policies:
-    print(policy)
+    print(f"{policy}")
+    print(f"{pp.pformat(policy.data)} \n")
 
-print("\nTotal number of policies {}".format(count))
+print(f"Total number of policies : {count}")
 policy_object = all_policies[0]
 
-print("\n\n get_all with filers")
+print("\n\nget_all with filters")
 all_policies = policies.get_all(filters={'name': policy_object.data["name"]})
 count = len(all_policies)
 for policy in all_policies:
-    print(policy)
+    print(f"{policy}")
+    print(f"{pp.pformat(policy.data)} \n")
 
-print("\n Total number of policies {}".format(count))
+print(f"Total number of policies : {count}")
 
-print("\n\n get_all with pagination")
+print("\n\nget_all with pagination")
 pagination = policies.get_all(limit=105, pagination=True, page_size=50)
 end = False
 while not end:
     data = pagination.data
     print("Page size:", len(data["resources"]))
-    print(data)
+    print(f"{pp.pformat(data)}")
 
     try:
         pagination.next_page()
     except HPESimpliVityException:
         end = True
 
-print("\n\n get_by_id")
+print("\n\nget_by_id")
 policy = policies.get_by_id(policy_object.data["id"])
-print(policy, policy.data)
+print(f"{policy}")
+print(f"{pp.pformat(policy.data)} \n")
 
-print("\n\n get_by_name")
+print("\n\nget_by_name")
 policy = policies.get_by_name(policy_object.data["name"])
-print(policy, policy.data)
+print(f"{policy}")
+print(f"{pp.pformat(policy.data)} \n")
 
-print("\n\n get_all VMs using this policy")
+print("\n\nget_all VMs using this policy")
 vms = policy.get_vms()
 print(policy.data)
-print(vms)
+print(f"{policy}")
+print(f"{pp.pformat(policy.data)} \n")
+print(f"{pp.pformat(vms)} \n")
+
+print("\n\ncreate policy")
+policy_name = "fixed_frequency_retention_policy"
+policy = policies.create(policy_name)
+print(policy, policy.data)
+print(f"{policy}")
+print(f"{pp.pformat(policy.data)} \n")
+
+print("\n\ndelete policy")
+policy.delete()

--- a/simplivity/resources/policies.py
+++ b/simplivity/resources/policies.py
@@ -73,6 +73,22 @@ class Policies(ResourceBase):
         """
         return Policy(self._connection, self._client, data)
 
+    def create(self, name, flags=None, timeout=-1):
+        """ create the new policy
+
+        Args:
+            flags: Dictionary of flags. Example: {'cluster_group_id': 'cluster_group_id'}
+            name : The name of the new policy created from this action.
+            timeout : Time out for the request in seconds.
+
+        Returns:
+            object: Policy object.
+        """
+        data = {"name": name}
+
+        affected_object = self._client.do_post(URL, data, timeout, flags)[0]
+        return self.get_by_id(affected_object["object_id"])
+
 
 class Policy(object):
     """Implements features available for a single Policy resource."""

--- a/tests/unit/resources/test_policies.py
+++ b/tests/unit/resources/test_policies.py
@@ -141,6 +141,19 @@ class PoliciesTest(unittest.TestCase):
 
         mock_get.assert_called_once_with('/policies/ABCDE/virtual_machines')
 
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_create_policy(self, mock_get, mock_post):
+        resource_data = [{'name': 'test', 'id': '12345'}]
+        mock_get.return_value = {policies.DATA_FIELD: resource_data}
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        policy_name = 'test'
+        policy = self.policies.create(policy_name)
+        data = {'name': 'test'}
+        self.assertIsInstance(policy, policies.Policy)
+        self.assertEqual(policy.data, resource_data[0])
+        mock_post.assert_called_once_with('/policies', data, custom_headers=None)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description**
Add support for the policy post endpoint that will enable the consumer to create SimpliVity policy

**Issues Resolved**

**Check List**
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.




**Comment 1**
svt-kmcdaniel 
should we use the return from policies.create to delete the policy?

That will ensure that we are deleting the policy that was created.

svt-hchaudhari 
Yes made the respective changes to get the list of policies and then retrieving the required policy object to delete the same.

**Comment 2**
svt-kmcdaniel 
should we use the return from policies.create to delete the policy?

That will ensure that we are deleting the policy that was created.
 
svt-hchaudhari 
Yes made the respective changes to get the list of policies and then retrieving the required policy object to delete the same.

**Comment 3**
svt-kmcdaniel 
need to ensure that policies.create() returns a Policy object within the unit tests

svt-hchaudhari 
Agreed, made the respective changes.