### PR TITLE
Feature/datastore create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,51 @@
-# v1.0.0
-#### Notes
-This is the first release of the SimpliVity Python SDK and it adds support for the below features.
 
-#### Features supported
- - Backup
- - Datastore
- - Host
- - OmniStack cluster
- - Policy
- - Virtual machine
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased] 
+
+### Added
+    - endpoint support for /backups/delete <POST>
+    - endpoint support for /backups/{bkpId} <DELETE>
+    - endpoint support for /datastore <POST>
+    - endpoint support for /datastore/{datastoreId} <DELETE>
+    - endpoint support for /hosts/{hostId}/remove_from_federation <POST>    
+    - endpoint support for /policies/{policyId} <DELETE>
+    - pull request template to facilitate pull requests
+    - query string support for post operations
+
+### Changed
+    - address unittest.assertequals deprecation warning within unit test cases
+    - leverage pprint in the ./examples/datastores.py to improve the overall readability of the output
+    - policy test cases to improve the existing code coverage metrics
+    - reformat existing docstrings to conform to Sphinx documentation requirements
+    - rename the unit test filenames to reflect which objects were being targeted
+
+### Fixed
+    - required __init__.py files to support unit test discovery
+    - resolve failing unit test cases
+    - url encode query string to support values that contain spaces
+
+### Removed
+    - external test dependency for mock module    
+
+## [v1.0.0] - 2019-12-04
+
+### Added
+    - endpoint support for /backups <GET>
+    - endpoint support for /datastores <GET>
+    - endpoint support for /hosts <GET>
+    - endpoint support for /omnistack_clusters <GET>
+    - endpoint support for /policies <GET>
+    - endpoint support for /virutal_machines <GET>
+    - endpoint support for /virutal_machines/set_policy <POST>
+    - endpoint support for /virutal_machines/{vmId} <GET>
+    - endpoint support for /virutal_machines/{vmId}/backup <POST>
+    - endpoint support for /virutal_machines/{vmId}/backup_parameters <POST>
+    - endpoint support for /virutal_machines/{vmId}/backups <GET>
+    - endpoint support for /virutal_machines/{vmId}/clone <POST>
+    - endpoint support for /virutal_machines/{vmId}/move <POST>
+    - endpoint support for /virutal_machines/{vmId}/set_policy <POST>

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -12,6 +12,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/backups/{bkpId}  </sub>                                                            |DELETE    |
 |     **Datastores**
 |<sub>/datastores	</sub>                                                                |GET       |
+|<sub>/datastores	</sub>                                                                |POST       |
 |<sub>/datastores/{datastoreId}  </sub>                                                   |DELETE    |
 |     **Hosts**
 |<sub>/hosts	</sub>                                                                    |GET       |

--- a/examples/datastores.py
+++ b/examples/datastores.py
@@ -1,5 +1,5 @@
 ###
-# (C) Copyright [2019] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2019-2020] Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,8 +14,12 @@
 # limitations under the License.
 ##
 
-from simplivity.ovc_client import OVC
+import pprint
+
 from simplivity.exceptions import HPESimpliVityException
+from simplivity.ovc_client import OVC
+
+pp = pprint.PrettyPrinter(indent=4)
 
 config = {
     "ip": "<ovc_ip>",
@@ -25,43 +29,57 @@ config = {
     }
 }
 
+config = {
+    "ip": "10.1.218.241",
+    "credentials": {
+        "username": "administrator@vsphere.local",
+        "password": "svtrfs29L@B",
+    },
+}
+
 ovc = OVC(config)
 datastores = ovc.datastores
 
-print("\n\n get_all with default params")
+print("\n\nget_all with default params")
 all_datastores = datastores.get_all()
-count = len(all_datastores)
 for datastore in all_datastores:
-    print(datastore.data)
+    print(f"{datastore}")
+    print(f"{pp.pformat(datastore.data)} \n")
+count = len(all_datastores)
+print(f"Total number of datastores : {count}")
 
-print("\nTotal number of datastores {}".format(count))
 datastore_object = all_datastores[0]
 
-print("\n\n get_all with filers")
-all_datatores = datastores.get_all(filters={'name': datastore_object.data["name"]})
-count = len(all_datastores)
+datastore_name = datastore_object.data["name"]
+print("\n\nget_all with filters")
+all_datastores = datastores.get_all(filters={'name': datastore_name})
 for datastore in all_datastores:
-    print(datastore.data)
+    print(f"{datastore}")
+    print(f"{pp.pformat(datastore.data)} \n")
+count = len(all_datastores)
+print(f"Total number of datastores : {count}")
 
-print("\n Total number of clusters {}".format(count))
-
-print("\n\n get_all with pagination")
-pagination = datastores.get_all(limit=105, pagination=True, page_size=50)
+print("\n\nget_all with pagination")
+pagination = datastores.get_all(limit=10, pagination=True, page_size=2)
 end = False
 while not end:
     data = pagination.data
-    print("Page size:", len(data["resources"]))
-    print(data)
+    print(f"page size : {len(data['resources'])}")
+    print(f"{pp.pformat(data)} \n")
 
     try:
         pagination.next_page()
     except HPESimpliVityException:
         end = True
 
-print("\n\n get_by_id")
-datastore = datastores.get_by_id(datastore_object.data["id"])
-print(datastore, datastore.data)
+datastore_id = datastore_object.data["id"]
+print("\n\nget_by_id")
+datastore = datastores.get_by_id(datastore_id)
+print(f"{datastore}")
+print(f"{pp.pformat(datastore.data)} \n")
 
-print("\n\n get_by_name")
+datastore_name = datastore_object.data["name"]
+print("\n\nget_by_name")
 datastore = datastores.get_by_name(datastore_object.data["name"])
-print(datastore, datastore.data)
+print(f"{datastore}")
+print(f"{pp.pformat(datastore.data)} \n")

--- a/examples/datastores.py
+++ b/examples/datastores.py
@@ -15,6 +15,7 @@
 ##
 
 import pprint
+import time
 
 from simplivity.exceptions import HPESimpliVityException
 from simplivity.ovc_client import OVC
@@ -29,14 +30,6 @@ config = {
     }
 }
 
-config = {
-    "ip": "10.1.218.241",
-    "credentials": {
-        "username": "administrator@vsphere.local",
-        "password": "svtrfs29L@B",
-    },
-}
-
 ovc = OVC(config)
 datastores = ovc.datastores
 
@@ -48,10 +41,21 @@ for datastore in all_datastores:
 count = len(all_datastores)
 print(f"Total number of datastores : {count}")
 
-datastore_object = all_datastores[0]
+# obtain cluster object for datastore create
+clusters = ovc.omnistack_clusters
+all_clusters = clusters.get_all()
+cluster_object = all_clusters[0]
+# obtain policy object for datastore create
+policies = ovc.policies
+all_policies = policies.get_all()
+policy_object = all_policies[0]
+print("\n\ndatastore create")
+datastore_object = datastores.create("datastore_test_from_sdk_" + str(time.time()), cluster_object, policy_object, 1024)
+print(f"{datastore_object}")
+print(f"{pp.pformat(datastore_object.data)} \n")
 
 datastore_name = datastore_object.data["name"]
-print("\n\nget_all with filters")
+print("\n\nget_all with name filter")
 all_datastores = datastores.get_all(filters={'name': datastore_name})
 for datastore in all_datastores:
     print(f"{datastore}")
@@ -83,3 +87,15 @@ print("\n\nget_by_name")
 datastore = datastores.get_by_name(datastore_object.data["name"])
 print(f"{datastore}")
 print(f"{pp.pformat(datastore.data)} \n")
+
+
+print("\n\ndatastore delete")
+all_datastores = datastores.get_all()
+count = len(all_datastores)
+print(f"Total number of datastores before delete: {count} \n")
+datastore_object.delete()
+print(f"{datastore_object}")
+print(f"{pp.pformat(datastore_object.data)} \n")
+all_datastores = datastores.get_all()
+count = len(all_datastores)
+print(f"Total number of datastores after delete: {count}")

--- a/simplivity/resources/datastores.py
+++ b/simplivity/resources/datastores.py
@@ -15,6 +15,8 @@
 ##
 
 from simplivity.resources.resource import ResourceBase
+from simplivity.resources import omnistack_clusters
+from simplivity.resources import policies
 
 URL = '/datastores'
 DATA_FIELD = 'datastores'
@@ -104,6 +106,41 @@ class Datastores(ResourceBase):
             object: Datastore object.
         """
         return Datastore(self._connection, self._client, data)
+
+    def create(self, datastore_name, cluster, policy, size=0, timeout=-1):
+        """Creates a new datastore.
+
+        Args:
+            datastore_name: The name of the new datastore created from this action.
+            cluster: Destination OmnistackCluster object/name.
+            policy: Object/name of the policy to assocaited with the new datastore.
+            size: The size in bytes of the new datastore.
+            timeout: Time out for the request in seconds.
+
+        Returns:
+            object: Datastore object.
+        """
+        method_url = "{}".format(URL)
+
+        if not isinstance(cluster, omnistack_clusters.OmnistackCluster):
+            # if passed name of the cluster
+            clusters_obj = omnistack_clusters.OmnistackClusters(self._connection)
+            cluster = clusters_obj.get_by_name(cluster)
+
+        if not isinstance(policy, policies.Policy):
+            # if passed name of the policy
+            policies_obj = policies.Policies(self._connection)
+            policy = policies_obj.get_by_name(policy)
+
+        data = {
+            "name": datastore_name,
+            "omnistack_cluster_id": cluster.data['id'],
+            "policy_id": policy.data['id'],
+            "size": size
+        }
+
+        out = self._client.do_post(method_url, data, timeout, None)
+        return self.get_by_id(out[0]["object_id"])
 
 
 class Datastore(object):


### PR DESCRIPTION
### Description
Add support for the datastore post endpoint that will enable the consumer to create SimpliVity datastores

### Issues Resolved

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
