### PR TITLE
Add support for restore functionality from backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
     - endpoint support for /backups/delete <POST>
     - endpoint support for /backups/{bkpId} <DELETE>
+    - endpoint support for /backups/{bkpId}/restore <POST>
     - endpoint support for /datastore <POST>
     - endpoint support for /datastore/{datastoreId} <DELETE>
     - endpoint support for /datastore/{datastoreId}/resize <POST>

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -10,6 +10,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/backups	</sub>                                                                    |GET       |
 |<sub>/backups/delete  </sub>                                                             |POST      |
 |<sub>/backups/{bkpId}  </sub>                                                            |DELETE    |
+|<sub>/backups/{bkpId}/restore  </sub>                                                    |POST      |
 |     **Datastores**
 |<sub>/datastores	</sub>                                                                |GET       |
 |<sub>/datastores	</sub>                                                                |POST       |

--- a/examples/backups.py
+++ b/examples/backups.py
@@ -1,5 +1,5 @@
 ###
-# (C) Copyright [2019] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2019-2020] Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,9 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ##
-
+import time
 from simplivity.ovc_client import OVC
 from simplivity.exceptions import HPESimpliVityException
+import pprint
 
 config = {
     "ip": "<ovc_ip>",
@@ -25,40 +26,89 @@ config = {
     }
 }
 
+pp = pprint.PrettyPrinter(indent=4)
+
 ovc = OVC(config)
 backups = ovc.backups
+machines = ovc.virtual_machines
+datastores = ovc.datastores
 
-print("\n\n get_all with default params")
+# variable declaration
+test_vm_name = "test_MySql-VM_restore"
+remote_datastore = "remoteDS"
+
+print("\n\nget_all with default params")
 all_backups = backups.get_all()
 count = len(all_backups)
 for backup in all_backups:
-    print(backup)
+    print(f"{backup}")
+    print(f"{pp.pformat(backup.data)} \n")
 
-print("\nTotal number of backups {}".format(count))
+print("\n\nTotal number of backups {}".format(count))
 backup_object = all_backups[0]
 
-print("\n\n get_all with filers")
+print("\n\nget_all with filters")
 all_backups = backups.get_all(filters={'name': backup_object.data["name"]})
 for backup in all_backups:
-    print(backup)
+    print(f"{backup}")
+    print(f"{pp.pformat(backup.data)} \n")
 
-print("\n\n get_all with pagination")
+
+print("\n\nget_all with pagination")
 pagination = backups.get_all(limit=105, pagination=True, page_size=50)
+
 end = False
 while not end:
     data = pagination.data
-    print("Page size:", len(data["resources"]))
-    print(data)
+    count = len(data["resources"])
+    print(f"Page size: {count}")
+    print(f"{pp.pformat(data)}")
 
     try:
         pagination.next_page()
     except HPESimpliVityException:
         end = True
 
-print("\n\n get_by_id")
+print("\n\nget_by_id")
 backup = backups.get_by_id(backup_object.data["id"])
-print(backup, backup.data)
+print(f"{backup}")
+print(f"{pp.pformat(backup.data)} \n")
 
-print("\n\n get_by_name")
+print("\n\nget_by_name")
 backup = backups.get_by_name(backup_object.data["name"])
-print(backup, backup.data)
+print(f"{backup}")
+print(f"{pp.pformat(backup.data)} \n")
+
+print("Create backup for the testing the restore functionality")
+vm = machines.get_by_name(test_vm_name)
+backup = vm.create_backup("backup_test_from_sdk_" + str(time.time()))
+print(f"{backup}")
+print(f"{pp.pformat(backup.data)} \n")
+
+# Create the new virtual machine on the same datastore
+restored_vm = backup.restore(False, "Restored_Machine_SDK_Same_DS")
+print(f"{restored_vm}")
+print(f"{pp.pformat(restored_vm.data)} \n")
+
+# Resets the original virtual machine to the same state it was in when the backup was created
+restored_vm = backup.restore(True)
+print(f"{restored_vm}")
+print(f"{pp.pformat(restored_vm.data)} \n")
+
+print("\nget the remote datastore for the restoring the VM ")
+datastore_object = datastores.get_by_name(remote_datastore)
+
+print(f"{datastore_object}")
+print(f"{pp.pformat(datastore_object.data)} \n")
+
+# Create the new virtual machine on the different datastore by passing object
+restored_vm = backup.restore(False, "Restored_Machine_SDK_anotherDS_Object", datastore_object)
+print(f"{restored_vm}")
+print(f"{pp.pformat(restored_vm.data)} \n")
+
+# Create the new virtual machine on the different datastore by passing name
+restored_vm = backup.restore(False, "Restored_Machine_SDK_anotherDS_Name", datastore_object.data["name"])
+print(f"{restored_vm}")
+print(f"{pp.pformat(restored_vm.data)} \n")
+
+backup.delete()


### PR DESCRIPTION
Signed-off-by: Hemant Chaudhari <hchaudhari@hpe.com>

### Description
Add support for the restore post endpoint that will enable the consumer to restore the original virtual machine or to create the new virtual machine

### Issues Resolved

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
