### PR TITLE
Add support for resizing of Simplivity datastore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /backups/{bkpId} <DELETE>
     - endpoint support for /datastore <POST>
     - endpoint support for /datastore/{datastoreId} <DELETE>
+    - endpoint support for /datastore/{datastoreId}/resize <POST>
     - endpoint support for /hosts/{hostId}/remove_from_federation <POST>    
     - endpoint support for /policies/{policyId} <DELETE>
     - endpoint support for /policies <POST>

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -14,6 +14,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/datastores	</sub>                                                                |GET       |
 |<sub>/datastores	</sub>                                                                |POST       |
 |<sub>/datastores/{datastoreId}  </sub>                                                   |DELETE    |
+|<sub>/datastores/{datastoreId}/resize  </sub>                                            |POST      |
 |     **Hosts**
 |<sub>/hosts	</sub>                                                                    |GET       |
 |<sub>/hosts/{hostId}/remove_from_federation  </sub>						|POST      |

--- a/examples/datastores.py
+++ b/examples/datastores.py
@@ -88,6 +88,12 @@ datastore = datastores.get_by_name(datastore_object.data["name"])
 print(f"{datastore}")
 print(f"{pp.pformat(datastore.data)} \n")
 
+# Resize the datastore add 1 GB to existing size
+print("\n\nresize the datastore")
+datastore_size = datastore_object.data["size"] + 1073741824
+datastore_object = datastore_object.resize(datastore_size)
+print(f"{datastore_object}")
+print(f"{pp.pformat(datastore_object.data)} \n")
 
 print("\n\ndatastore delete")
 all_datastores = datastores.get_all()

--- a/simplivity/resources/datastores.py
+++ b/simplivity/resources/datastores.py
@@ -156,3 +156,23 @@ class Datastore(object):
         resource_uri = "{}/{}".format(URL, self.data["id"])
         self._client.do_delete(resource_uri, timeout, None)
         self.data = None
+
+    def resize(self, size, timeout=-1):
+        """Resizes a datastore.
+
+        Args:
+            size: The size in bytes.
+            timeout: Time out for the request in seconds.
+
+        Returns:
+            object: Datastore object.
+
+        """
+        resource_uri = "{}/{}/resize".format(URL, self.data["id"])
+        data = {"size": size}
+        out = self._client.do_post(resource_uri, data, timeout, None)
+        datastore = Datastores(self._connection)
+        datastore_obj = datastore.get_by_id(out[0]["object_id"])
+        self.data = datastore_obj.data
+
+        return self

--- a/tests/unit/resources/test_datastores.py
+++ b/tests/unit/resources/test_datastores.py
@@ -160,6 +160,19 @@ class DatastoresTest(unittest.TestCase):
         datastore.delete()
         mock_delete.assert_called_once_with('/datastores/12345', custom_headers=None)
 
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_resize(self, mock_get, mock_post):
+        resource_data = [{'id': '12345', 'name': 'ds1', 'size': 2048}]
+        mock_get.return_value = {datastores.DATA_FIELD: resource_data}
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        datastore_data = {'name': 'name1', 'id': '12345', 'size': 1024}
+        datastore = self.datastores.get_by_data(datastore_data)
+        datastore.resize(2048)
+        self.assertIsInstance(datastore, datastores.Datastore)
+        self.assertEqual(datastore.data, resource_data[0])
+        mock_post.assert_called_once_with('/datastores/12345/resize', {'size': 2048}, custom_headers=None)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Hemant Chaudhari <hchaudhari@hpe.com>

### Description
Add support for resizing of Simplivity datastore

### Issues Resolved


### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
