### PR TITLE
Add support for powering off virtual machine on simplivity datastore.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /policies <POST>
     - endpoint support for /policies/{policyId} <DELETE>
     - endpoint support for /policies/{policyId}/rules <POST>
+    - endpoint support for /virtual_machines/{vmId}/power_off <POST>
     - missing ovc client host unit tests to improve code coverage
     - pull request template to facilitate pull requests
     - query string support for post operations

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -40,4 +40,5 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/virtual_machines/{vmId}/backups	</sub>                                            |GET       |
 |<sub>/virtual_machines/{vmId}/clone	</sub>                                            |POST      |
 |<sub>/virtual_machines/{vmId}/move	</sub>                                                |POST      |
+|<sub>/virtual_machines/{vmId}/power_off	</sub>                                        |POST      |
 |<sub>/virtual_machines/{vmId}/set_policy	</sub>                                        |POST      |

--- a/examples/virtual_machines.py
+++ b/examples/virtual_machines.py
@@ -15,9 +15,12 @@
 ##
 
 import time
+import pprint
 
 from simplivity.ovc_client import OVC
 from simplivity.exceptions import HPESimpliVityException
+
+pp = pprint.PrettyPrinter(indent=4)
 
 config = {
     "ip": "<ovc_ip>",
@@ -42,111 +45,130 @@ datastore_2_name = "DS2"
 policy_name = "Simple"
 omnistack_cluster_name = "Epyc"
 
-
-print("\n\n get_all with default params")
+print("\n\nget_all with default params")
 vms = machines.get_all()
 count = len(vms)
 for vm in vms:
-    print(vm.data)
+    print(f"{vm}")
+    print(f"{pp.pformat(vm.data)} \n")
+print(f"Total number of vms : {count}")
 
-print("\nTotal number of vms {}".format(count))
 vm_object = vms[0]
 
-print("\n\n get_all with filers")
+print("\n\nget_all with filers")
 vms = machines.get_all(filters={'name': vm_object.data["name"]})
 count = len(vms)
 for vm in vms:
-    print(vm.data)
+    print(f"{pp.pformat(vm.data)} \n")
+print(f"Total number of vms : {count}")
 
-print("\n Total number of vms {}".format(count))
-
-print("\n\n get_all with pagination")
+print("\n\nget_all with pagination")
 pagination = machines.get_all(limit=500, pagination=True, page_size=50)
 end = False
 while not end:
     data = pagination.data
     print("Page size:", len(data["resources"]))
-    print(data)
-
+    print(f"{pp.pformat(data)}")
     try:
         pagination.next_page()
     except HPESimpliVityException:
         end = True
 
-print("\n\n get_by_id")
+print("\n\nget_by_id")
 vm = machines.get_by_id(vm_object.data["id"])
-print(vm, vm.data)
+print(f"{vm}")
+print(f"{pp.pformat(vm.data)} \n")
 
-print("\n\n get_by_name")
+print("\n\nget_by_name")
 vm1 = machines.get_by_name(vm_1_name)
-print(vm1, vm1.data)
+print(f"{vm1}")
+print(f"{pp.pformat(vm1.data)} \n")
 
 vm2 = machines.get_by_name(vm_2_name)
-print(vm2, vm2.data)
+print(f"{vm2}")
+print(f"{pp.pformat(vm2.data)} \n")
 
 policy = policies.get_by_name(policy_name)
-print("Policy: ", policy, policy.data)
 
-print("\n\n get_backups")
+print(f"{policy}")
+print(f"{pp.pformat(policy.data)} \n")
+
+print("\n\nget_backups")
 backups = vm2.get_backups()
 for backup in backups:
-    print(backup.data)
+    print(f"{pp.pformat(backup.data)} \n")
 
-print("\n\n set_policy_for_multiple_vms")
+print("\n\nset_policy_for_multiple_vms")
 vms = [vm1, vm2]
 response = machines.set_policy_for_multiple_vms(policy, vms)
 for vm in response:
-    print(vm, vm.data)
+    print(f"{vm}")
+    print(f"{pp.pformat(vm.data)} \n")
 
-print("\n\n clone")
+print("\n\nclone")
 cloned_vm = vm1.clone(vm_1_name + " clone_test")
-print(cloned_vm, cloned_vm.data)
+print(f"{cloned_vm}")
+print(f"{pp.pformat(cloned_vm.data)} \n")
 
-print("\n\n clone and move to different datastore")
+
+print("\n\nclone and move to different datastore")
 print("VM id :", vm1.data["id"])
 cloned_vm = vm1.clone(vm_1_name + " clone_move_test", datastore=datastore_2_name)
 
 print("\nMoved vm details")
-print(cloned_vm, cloned_vm.data)
+print(f"{cloned_vm}")
+print(f"{pp.pformat(cloned_vm.data)} \n")
 
 print("\nMove VM to different datastore using datastore's name")
-print("\n VM data before move")
-print(vm1.data)
+print("\nVM data before move")
+print(f"{vm1}")
+print(f"{pp.pformat(vm1.data)} \n")
 
 newvm = vm2.move(vm_2_name + "_move_test", datastore_2_name)
-print("\n New VM details, after move")
-print(newvm.data)
+print("\nNew VM details, after move")
+print(f"{newvm}")
+print(f"{pp.pformat(newvm.data)} \n")
 
 newvm = newvm.move(vm_2_name, datastore_1_name)
-print("\n Move VM back to the original datastore")
-print(newvm.data)
+print("\nMove VM back to the original datastore")
+print(f"{newvm}")
+print(f"{pp.pformat(newvm.data)} \n")
 
-print("\n Move using datastore object")
+print("\nMove using datastore object")
 datastore = datastores.get_by_name(datastore_2_name)
-newvm = vm1.move(vm_1_name + "move_with_obj", datastore)
-print(newvm.data)
+newvm = vm2.move(vm_2_name + "move_with_obj", datastore)
+print(f"{newvm}")
+print(f"{pp.pformat(newvm.data)} \n")
 
-print("\n Move VM back to the original datastore")
-newvm = newvm.move(vm_1_name, datastore_1_name)
-print(newvm.data)
+print("\nMove VM back to the original datastore")
+newvm = newvm.move(vm_2_name, datastore_1_name)
+print(f"{newvm}")
+print(f"{pp.pformat(newvm.data)} \n")
 
-print("\n create_backup")
+print("\ncreate_backup")
 cluster = omnistack_clusters.get_by_name(omnistack_cluster_name)
-print("Cluster data", cluster.data)
+print("\nCluster data")
+print(f"{pp.pformat(cluster.data)} \n")
 
 vm_backup = vm2.create_backup("backup_test_from_sdk_" + str(time.time()), cluster)
-print(vm_backup.data)
+print(f"{pp.pformat(vm_backup.data)} \n")
 
 print("Get backups of a single vm")
-backups = vm1.get_backups()
-print(backups)
+backups = vm2.get_backups()
+pp.pprint(backups)
 
-print("\n Set backup parameters of a VM")
+print("\nSet backup parameters of a VM")
 guest_username = "svt"
 guest_password = "svtpassword"
 set_parameters = vm1.set_backup_parameters(guest_username, guest_password)
-print(set_parameters)
+print(f"{pp.pformat(set_parameters.data)} \n")
 
-print("\n Set policy")
+print("\nSet policy")
+vm1 = machines.get_by_name(vm_1_name)
 set_policy = vm1.set_policy(policy_name)
-print(set_policy.data)
+print(f"{pp.pformat(set_policy.data)} \n")
+
+print("\nPower off")
+vm1 = machines.get_by_name(vm_1_name)
+vm_powered_off = vm1.power_off()
+print(f"{pp.pformat(vm_powered_off.data)} \n")

--- a/simplivity/resources/virtual_machines.py
+++ b/simplivity/resources/virtual_machines.py
@@ -323,3 +323,21 @@ class VirtualMachine(object):
         self.__refresh()
 
         return self
+
+    def power_off(self, timeout=-1):
+        """Power off virtual machine.
+
+        Args:
+            timeout: Time out for the request in seconds.
+
+        Returns:
+            self: Returns the same object.
+        """
+        method_url = "{}/{}/power_off".format(URL, self.data["id"])
+        custom_headers = {}
+        custom_headers['Content-type'] = 'application/vnd.simplivity.v1.11+json'
+
+        self._client.do_post(method_url, None, timeout, custom_headers, None)
+        self.__refresh()
+
+        return self

--- a/simplivity/resources/virtual_machines.py
+++ b/simplivity/resources/virtual_machines.py
@@ -334,10 +334,9 @@ class VirtualMachine(object):
             self: Returns the same object.
         """
         method_url = "{}/{}/power_off".format(URL, self.data["id"])
-        custom_headers = {}
-        custom_headers['Content-type'] = 'application/vnd.simplivity.v1.11+json'
+        custom_headers = {'Content-type': 'application/vnd.simplivity.v1.11+json'}
 
-        self._client.do_post(method_url, None, timeout, custom_headers, None)
+        self._client.do_post(method_url, None, timeout, custom_headers)
         self.__refresh()
 
         return self

--- a/tests/unit/resources/test_virtual_machines.py
+++ b/tests/unit/resources/test_virtual_machines.py
@@ -273,6 +273,18 @@ class VirtualMachinesTest(unittest.TestCase):
         mock_post.assert_called_once_with('/virtual_machines/12345/set_policy',
                                           {'policy_id': 'policy12345'}, custom_headers=None)
 
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_power_off(self, mock_get, mock_post):
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        mock_get.return_value = {'virtual_machines': {'id': '12345'}}
+
+        vm1_data = {'name': 'name1', 'id': '12345'}
+        vm = self.machines.get_by_data(vm1_data)
+
+        vm.power_off()
+        mock_post.assert_called_once_with('/virtual_machines/12345/power_off', None, custom_headers={'Content-type': 'application/vnd.simplivity.v1.11+json'})
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Description
Add support for powering off virtual machine on simplivity datastore.

### Issues Resolved
None

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
