### PR TITLE
Add support to set policy on the SimpliVity datastore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /datastore <POST>
     - endpoint support for /datastore/{datastoreId} <DELETE>
     - endpoint support for /datastore/{datastoreId}/resize <POST>
+    - endpoint support for /datastore/{datastoreId}/set_policy <POST>
     - endpoint support for /hosts/{hostId}/remove_from_federation <POST>    
     - endpoint support for /policies <POST>
     - endpoint support for /policies/{policyId} <DELETE>

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -18,6 +18,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/datastores	</sub>                                                                |POST       |
 |<sub>/datastores/{datastoreId}  </sub>                                                   |DELETE    |
 |<sub>/datastores/{datastoreId}/resize  </sub>                                            |POST      |
+|<sub>/datastores/{datastoreId}/set_policy  </sub>                                        |POST      |
 |     **Hosts**
 |<sub>/hosts	</sub>                                                                    |GET       |
 |<sub>/hosts/{hostId}/remove_from_federation  </sub>						|POST      |

--- a/examples/datastores.py
+++ b/examples/datastores.py
@@ -95,13 +95,27 @@ datastore_object = datastore_object.resize(datastore_size)
 print(f"{datastore_object}")
 print(f"{pp.pformat(datastore_object.data)} \n")
 
+# Set policy to the datastore
+print("\n\nset policy on the datastore")
+policy_object = policies.create("fixed_retention_policy")
+print(f"{policy_object}")
+print(f"{pp.pformat(policy_object.data)} \n")
+
+datastore_object.set_policy(policy_object)
+print(f"{datastore_object}")
+print(f"{pp.pformat(datastore_object.data)} \n")
+
 print("\n\ndatastore delete")
 all_datastores = datastores.get_all()
 count = len(all_datastores)
 print(f"Total number of datastores before delete: {count} \n")
 datastore_object.delete()
+
+# delete the new policy created
+policy_object.delete()
 print(f"{datastore_object}")
 print(f"{pp.pformat(datastore_object.data)} \n")
+
 all_datastores = datastores.get_all()
 count = len(all_datastores)
 print(f"Total number of datastores after delete: {count}")

--- a/simplivity/resources/datastores.py
+++ b/simplivity/resources/datastores.py
@@ -151,6 +151,11 @@ class Datastore(object):
         self._connection = connection
         self._client = resource_client
 
+    def __refresh(self):
+        """Updates the datastore data."""
+        resource_uri = "{}/{}".format(URL, self.data["id"])
+        self.data = self._client.do_get(resource_uri)['datastore']
+
     def delete(self, timeout=-1):
         """Deletes a datastore."""
         resource_uri = "{}/{}".format(URL, self.data["id"])
@@ -174,5 +179,27 @@ class Datastore(object):
         datastore = Datastores(self._connection)
         datastore_obj = datastore.get_by_id(out[0]["object_id"])
         self.data = datastore_obj.data
+
+        return self
+
+    def set_policy(self, policy, timeout=-1):
+        """Sets the backup policy for a datastore.
+
+        Args:
+            policy: Policy object/name
+            timeout: Time out for the request in seconds.
+
+        Returns:
+            object: Datastore object.
+
+        """
+        resource_uri = "{}/{}/set_policy".format(URL, self.data["id"])
+        if not isinstance(policy, policies.Policy):
+            # if passed name of the policy
+            policy = policies.Policies(self._connection).get_by_name(policy)
+
+        data = {"policy_id": policy.data['id']}
+        self._client.do_post(resource_uri, data, timeout, None)
+        self.__refresh()
 
         return self

--- a/tests/unit/resources/test_datastores.py
+++ b/tests/unit/resources/test_datastores.py
@@ -173,6 +173,41 @@ class DatastoresTest(unittest.TestCase):
         self.assertEqual(datastore.data, resource_data[0])
         mock_post.assert_called_once_with('/datastores/12345/resize', {'size': 2048}, custom_headers=None)
 
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_set_policy_with_policy_name(self, mock_get, mock_post):
+        resource_data = {'name': 'ds1', 'id': '12345', 'policy_id': '4567'}
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        policy_name = 'policy1'
+        mock_get.side_effect = [{'policies': [{'name': policy_name, 'id': '4567'}]},
+                                {'datastore': resource_data}]
+
+        datastore_data = {'name': 'ds1', 'id': '12345', 'policy_id': '7890'}
+        datastore = self.datastores.get_by_data(datastore_data)
+        datastore.set_policy(policy_name)
+        self.assertIsInstance(datastore, datastores.Datastore)
+        self.assertEqual(datastore.data, resource_data)
+
+        mock_post.assert_called_once_with('/datastores/12345/set_policy', {'policy_id': '4567'},
+                                          custom_headers=None)
+
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_set_policy_with_policy_obj(self, mock_get, mock_post):
+        resource_data = {'name': 'ds1', 'id': '12345', 'policy_id': '7890'}
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        mock_get.return_value = {'datastore': resource_data}
+        policy_obj = self.policies.get_by_data({'id': '4567', 'name': 'policy1'})
+
+        datastore_data = {'name': 'ds1', 'id': '12345', 'policy_id': '7890'}
+        datastore = self.datastores.get_by_data(datastore_data)
+        datastore.set_policy(policy_obj)
+        self.assertIsInstance(datastore, datastores.Datastore)
+        self.assertEqual(datastore.data, resource_data)
+
+        mock_post.assert_called_once_with('/datastores/12345/set_policy', {'policy_id': '4567'},
+                                          custom_headers=None)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Hemant Chaudhari <hchaudhari@hpe.com>

### Description
Add support to set policy on the SimpliVity datastore

### Issues Resolved
NA

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
