### PR TITLE
Add support to fetch the rule from SimpliVity policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /policies <POST>
     - endpoint support for /policies/{policyId} <DELETE>
     - endpoint support for /policies/{policyId}/rules <POST>
+    - endpoint support for /policies/{policyId}/rules/{ruleId} <GET>
     - endpoint support for /virtual_machines/{vmId}/power_off <POST>
     - missing ovc client host unit tests to improve code coverage
     - pull request template to facilitate pull requests

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -31,6 +31,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/policies</sub>                                                                     |POST      |
 |<sub>/policies/{policyId} </sub>                                                         |DELETE    |
 |<sub>/policies/{policyId}/rules </sub>                                                   |POST      |
+|<sub>/policies/{policyId}/rules/{ruleId} </sub>                                          |GET       |
 |     **Virtual Machines**
 |<sub>/virtual_machines	</sub>                                                            |GET       |
 |<sub>/virtual_machines/set_policy	</sub>                                                |POST      |

--- a/examples/policies.py
+++ b/examples/policies.py
@@ -111,5 +111,11 @@ policy.create_rules(single_rule)
 print(f"{policy}")
 print(f"{pp.pformat(policy.data)} \n")
 
+print("\n\nget rule")
+all_rules = policy.data["rules"]
+for rule in all_rules:
+    rule_obj = policy.get_rule(rule.get('id'))
+    print(f"{pp.pformat(rule_obj)} \n")
+
 print("\n\ndelete policy")
 policy.delete()

--- a/simplivity/resources/policies.py
+++ b/simplivity/resources/policies.py
@@ -172,3 +172,14 @@ class Policy(object):
         self.__refresh()
 
         return self
+
+    def get_rule(self, rule_id):
+        """Retrieves the specified policy rule
+           Args:
+                rule_id : Rule id to be retrieved
+
+           Returns:
+                Rules object
+        """
+        resource_uri = "{}/{}/rules/{}".format(URL, self.data["id"], rule_id)
+        return self._client.do_get(resource_uri)

--- a/tests/unit/resources/test_policies.py
+++ b/tests/unit/resources/test_policies.py
@@ -209,6 +209,14 @@ class PoliciesTest(unittest.TestCase):
         self.assertEqual(policy.data, resource_data[0])
         mock_post.assert_called_once_with('/policies?cluster_group_id=abcdefg', {'name': policy_name}, custom_headers=None)
 
+    @mock.patch.object(Connection, "get")
+    def test_get_rule(self, mock_get):
+        resources_data = [{'frequency': 1, 'retention': 5, 'id': 12345}]
+        mock_get.return_value = {"rules": resources_data}
+        policy_obj = self.policies.get_by_data({'id': '67890', 'name': 'name', 'rules': resources_data})
+        policy_obj.get_rule(12345)
+        self.assertEqual(policy_obj.data['rules'], resources_data)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Hemant Chaudhari <hchaudhari@hpe.com>

### Description
Add support to fetch the rule from SimpliVity policy

### Issues Resolved
NA

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.

### Note:
We will write the example for get policy once create policy PR is merged.
