### PR TITLE
Add support for fetching the hardware details for the host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /datastore/{datastoreId} <DELETE>
     - endpoint support for /datastore/{datastoreId}/resize <POST>
     - endpoint support for /hosts/{hostId}/remove_from_federation <POST>    
+    - endpoint support for /hosts/{hostId}/hardware <GET>
     - endpoint support for /policies <POST>
     - endpoint support for /policies/{policyId} <DELETE>
     - missing ovc client host unit tests to improve code coverage

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -21,6 +21,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |     **Hosts**
 |<sub>/hosts	</sub>                                                                    |GET       |
 |<sub>/hosts/{hostId}/remove_from_federation  </sub>						|POST      |
+|<sub>/hosts/{hostId}/hardware  </sub>						          |GET      |
 |     **OmniStack Clusters**
 |<sub>/omnistack_clusters	</sub>                                                        |GET       |
 |     **Policies**

--- a/examples/hosts.py
+++ b/examples/hosts.py
@@ -1,5 +1,5 @@
 ###
-# (C) Copyright [2019] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2019-2020] Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ##
+import pprint
 
 from simplivity.ovc_client import OVC
 from simplivity.exceptions import HPESimpliVityException
@@ -25,43 +26,54 @@ config = {
     }
 }
 
+pp = pprint.PrettyPrinter(indent=4)
+
 ovc = OVC(config)
 hosts = ovc.hosts
 
-print("\n\n get_all with default params")
+print("\n\nget_all with default params")
 all_hosts = hosts.get_all()
 count = len(all_hosts)
 for host in all_hosts:
-    print(host.data)
+    print(f"{host}")
+    print(f"{pp.pformat(host.data)} \n")
 
-print("\nTotal number of hosts {}".format(count))
+print("\n\nTotal number of hosts {}".format(count))
 host_object = all_hosts[0]
 
-print("\n\n get_all with filers")
+print("\n\nget_all with filters")
 all_hosts = hosts.get_all(filters={'name': host_object.data["name"]})
 count = len(all_hosts)
 for host in all_hosts:
-    print(host.data)
+    print(f"{host}")
+    print(f"{pp.pformat(host.data)} \n")
 
-print("\n Total number of hosts {}".format(count))
+print("\n\nTotal number of hosts {}".format(count))
 
-print("\n\n get_all with pagination")
+print("\n\nget_all with pagination")
 pagination = hosts.get_all(limit=105, pagination=True, page_size=50)
 end = False
 while not end:
     data = pagination.data
-    print("Page size:", len(data["resources"]))
-    print(data)
+    count = len(data["resources"])
+    print(f"Page size: {count}")
+    print(f"{pp.pformat(data)}")
 
     try:
         pagination.next_page()
     except HPESimpliVityException:
         end = True
 
-print("\n\n get_by_id")
-hosst = hosts.get_by_id(host_object.data["id"])
-print(host, host.data)
+print("\n\nget_by_id")
+host = hosts.get_by_id(host_object.data["id"])
+print(f"{host}")
+print(f"{pp.pformat(host.data)} \n")
 
-print("\n\n get_by_name")
+print("\n\nget_by_name")
 host = hosts.get_by_name(host_object.data["name"])
-print(host, host.data)
+print(f"{host}")
+print(f"{pp.pformat(host.data)} \n")
+
+print("\n\nget hardware details for the host")
+host_hardware = host.get_hardware()
+print(f"{pp.pformat(host_hardware)} \n")

--- a/simplivity/resources/hosts.py
+++ b/simplivity/resources/hosts.py
@@ -170,3 +170,8 @@ class Host(object):
 
         self._client.do_post(method_url, data, timeout, http_headers)
         self.data = None
+
+    def get_hardware(self):
+        """Retrieves the hardware information for the host"""
+        resource_uri = "{}/{}/hardware".format(URL, self.data["id"])
+        return self._client.do_get(resource_uri)

--- a/tests/unit/resources/test_hosts.py
+++ b/tests/unit/resources/test_hosts.py
@@ -122,6 +122,19 @@ class HostsTest(unittest.TestCase):
             custom_headers={"Content-type": "application/vnd.simplivity.v1.9+json"},
         )
 
+    @mock.patch.object(Connection, "get")
+    def test_get_hardware(self, mock_get):
+        resource_data = {"host": {"serial_number": "abcdef", "manufacturer": "HPE",
+                                  "model_number": "ProLiant DL380 Gen9", "status": "GREEN",
+                                  "host_id": "12345"
+                                  }}
+        mock_get.return_value = resource_data
+        host_data = {"id": "12345"}
+        host = self.hosts.get_by_data(host_data)
+
+        hardware_data = host.get_hardware()
+        self.assertEqual(hardware_data, resource_data)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Hemant Chaudhari <hchaudhari@hpe.com>

### Description
Add support for fetching the hardware details for the host

### Issues Resolved
NA

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
