### PR TITLE
Add support to fetch the virtual controller status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /datastore/{datastoreId}/set_policy <POST>
     - endpoint support for /hosts/{hostId}/remove_from_federation <POST>    
     - endpoint support for /hosts/{hostId}/hardware <GET>
+    - endpoint support for /hosts/{hostId}/virtual_controller_shutdown_status <GET>
     - endpoint support for /policies <POST>
     - endpoint support for /policies/{policyId} <DELETE>
     - endpoint support for /policies/{policyId}/rules <POST>

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -23,6 +23,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/hosts	</sub>                                                                    |GET       |
 |<sub>/hosts/{hostId}/remove_from_federation  </sub>						|POST      |
 |<sub>/hosts/{hostId}/hardware  </sub>						          |GET      |
+|<sub>/hosts/{hostId}/virtual_controller_shutdown_status  </sub>                          |GET      |
 |     **OmniStack Clusters**
 |<sub>/omnistack_clusters	</sub>                                                        |GET       |
 |     **Policies**

--- a/examples/hosts.py
+++ b/examples/hosts.py
@@ -77,3 +77,7 @@ print(f"{pp.pformat(host.data)} \n")
 print("\n\nget hardware details for the host")
 host_hardware = host.get_hardware()
 print(f"{pp.pformat(host_hardware)} \n")
+
+print("\n\nget virtual controller shutdown status")
+virtual_controller_status = host.get_virtual_controller_shutdown_status()
+print(f"{pp.pformat(virtual_controller_status)} \n")

--- a/simplivity/resources/hosts.py
+++ b/simplivity/resources/hosts.py
@@ -175,3 +175,8 @@ class Host(object):
         """Retrieves the hardware information for the host"""
         resource_uri = "{}/{}/hardware".format(URL, self.data["id"])
         return self._client.do_get(resource_uri)
+
+    def get_virtual_controller_shutdown_status(self):
+        """Retrieves the shutdown status of the Virtual Controller"""
+        resource_uri = "{}/{}/virtual_controller_shutdown_status".format(URL, self.data["id"])
+        return self._client.do_get(resource_uri)

--- a/tests/unit/resources/test_hosts.py
+++ b/tests/unit/resources/test_hosts.py
@@ -128,12 +128,23 @@ class HostsTest(unittest.TestCase):
                                   "model_number": "ProLiant DL380 Gen9", "status": "GREEN",
                                   "host_id": "12345"
                                   }}
+
         mock_get.return_value = resource_data
         host_data = {"id": "12345"}
         host = self.hosts.get_by_data(host_data)
 
         hardware_data = host.get_hardware()
         self.assertEqual(hardware_data, resource_data)
+
+    @mock.patch.object(Connection, "get")
+    def test_get_virtual_controller_shutdown_status(self, mock_get):
+        resource_data = {"shutdown_status": {"status": "NONE"}}
+        mock_get.return_value = resource_data
+        host_data = {"id": "12345"}
+        host = self.hosts.get_by_data(host_data)
+
+        virtual_controller_status = host.get_virtual_controller_shutdown_status()
+        self.assertEqual(virtual_controller_status, resource_data)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Signed-off-by: Hemant Chaudhari <hchaudhari@hpe.com>

### Description
Add support to fetch the virtual controller status

### Issues Resolved
None

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
