### PR TITLE
Add support to delete the rule from Simplivity policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /policies/{policyId} <DELETE>
     - endpoint support for /policies/{policyId}/rules <POST>
     - endpoint support for /policies/{policyId}/rules/{ruleId} <GET>
+    - endpoint support for /policies/{policyId}/rules/{ruleId} <DELETE>
     - endpoint support for /virtual_machines/{vmId}/power_off <POST>
     - missing ovc client host unit tests to improve code coverage
     - pull request template to facilitate pull requests

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -32,6 +32,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/policies/{policyId} </sub>                                                         |DELETE    |
 |<sub>/policies/{policyId}/rules </sub>                                                   |POST      |
 |<sub>/policies/{policyId}/rules/{ruleId} </sub>                                          |GET       |
+|<sub>/policies/{policyId}/rules/{ruleId} </sub>                                          |DELETE    |
 |     **Virtual Machines**
 |<sub>/virtual_machines	</sub>                                                            |GET       |
 |<sub>/virtual_machines/set_policy	</sub>                                                |POST      |

--- a/examples/policies.py
+++ b/examples/policies.py
@@ -117,5 +117,11 @@ for rule in all_rules:
     rule_obj = policy.get_rule(rule.get('id'))
     print(f"{pp.pformat(rule_obj)} \n")
 
+print("\n\ndelete rule")
+rule_id = policy.data["rules"][0]['id']
+policy.delete_rule(rule_id)
+print(f"{policy}")
+print(f"{pp.pformat(policy.data)} \n")
+
 print("\n\ndelete policy")
 policy.delete()

--- a/simplivity/resources/policies.py
+++ b/simplivity/resources/policies.py
@@ -169,6 +169,22 @@ class Policy(object):
 
         flags = {'replace_all_rules': replace_all_rules}
         self._client.do_post(resource_uri, rules, timeout, None, flags)[0]
+
+        self.__refresh()
+
+        return self
+
+    def delete_rule(self, rule_id, timeout=-1):
+        """Removes a policy rule
+        Args:
+            rule_id: Rule id to be deleted
+            timeout: Time out for the request in seconds.
+
+        Returns:
+            self: Returns the policy object.
+        """
+        resource_uri = "{}/{}/rules/{}".format(URL, self.data["id"], rule_id)
+        self._client.do_delete(resource_uri, timeout, None)
         self.__refresh()
 
         return self

--- a/tests/unit/resources/test_policies.py
+++ b/tests/unit/resources/test_policies.py
@@ -217,6 +217,21 @@ class PoliciesTest(unittest.TestCase):
         policy_obj.get_rule(12345)
         self.assertEqual(policy_obj.data['rules'], resources_data)
 
+    @mock.patch.object(Connection, "delete")
+    @mock.patch.object(Connection, "get")
+    def test_delete_rule(self, mock_get, mock_delete):
+        mock_delete.return_value = None, [{'object_id': '67890'}]
+        resources_data = {"rules": [], "name": "name", "id": "67890"}
+        mock_get.return_value = {'policy': resources_data}
+        policy_data = {"rules": [{"frequency": 5, "id": "12345", "retention": 1}], "name": "name",
+                       "id": "67890"}
+
+        policy = self.policies.get_by_data(policy_data)
+
+        response_policy = policy.delete_rule(12345)
+        self.assertEqual(response_policy.data, resources_data)
+        mock_delete.assert_called_once_with('/policies/67890/rules/12345', custom_headers=None)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Hemant Chaudhari <hchaudhari@hpe.com>

### Description
Add support to delete the rule from Simplivity policy

### Issues Resolved
None

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
