### PR TITLE
Add support to suspend the Simplivity policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /hosts/{hostId}/virtual_controller_shutdown_status <GET>
     - endpoint support for /omnistack_clusters/time_zone_list <GET>
     - endpoint support for /policies <POST>
+    - endpoint support for /policies/suspend <POST>
     - endpoint support for /policies/{policyId} <DELETE>
     - endpoint support for /policies/{policyId}/rules <POST>
     - endpoint support for /policies/{policyId}/rules/{ruleId} <GET>

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -32,6 +32,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |     **Policies**
 |<sub>/policies	</sub>                                                                    |GET       |
 |<sub>/policies</sub>                                                                     |POST      |
+|<sub>/policies/suspend </sub>                                                            |POST      |
 |<sub>/policies/{policyId} </sub>                                                         |DELETE    |
 |<sub>/policies/{policyId}/rules </sub>                                                   |POST      |
 |<sub>/policies/{policyId}/rules/{ruleId} </sub>                                          |GET       |

--- a/examples/policies.py
+++ b/examples/policies.py
@@ -30,6 +30,9 @@ config = {
 
 ovc = OVC(config)
 policies = ovc.policies
+hosts = ovc.hosts
+clusters = ovc.omnistack_clusters
+cluster_groups = ovc.cluster_groups
 
 print("\n\nget_all with default params")
 all_policies = policies.get_all()
@@ -122,6 +125,25 @@ rule_id = policy.data["rules"][0]['id']
 policy.delete_rule(rule_id)
 print(f"{policy}")
 print(f"{pp.pformat(policy.data)} \n")
+
+print("\n\nsuspend policy on host")
+host = hosts.get_all()[0]
+policies.suspend(host)
+
+print("\n\nsuspend policy on omnistack_cluster")
+cluster = clusters.get_all()[0]
+policies.suspend(cluster)
+
+""" cluster_group options works only with setup having MVA, please use below code for setup with MVA
+cluster_group = cluster_groups.get_all()[0]
+print(f"{cluster_group}")
+print(f"{pp.pformat(cluster_group.data)} \n")
+policies.suspend(cluster_group)
+"""
+""" federation options works only with setup NOT having MVA, please use below code for setup without MVA
+print("\n\nsuspend policy on federation")
+policies.suspend()
+"""
 
 print("\n\ndelete policy")
 policy.delete()

--- a/simplivity/resources/cluster_groups.py
+++ b/simplivity/resources/cluster_groups.py
@@ -78,6 +78,8 @@ class ClusterGroups(ResourceBase):
 class ClusterGroup(object):
     """Implements features available for single cluster group resource."""
 
+    OBJECT_TYPE = 'cluster_group'
+
     def __init__(self, connection, resource_client, data):
         self.data = data
         self._connection = connection

--- a/simplivity/resources/hosts.py
+++ b/simplivity/resources/hosts.py
@@ -147,6 +147,8 @@ class Hosts(ResourceBase):
 class Host(object):
     """Implements features available for single Host resource."""
 
+    OBJECT_TYPE = 'host'
+
     def __init__(self, connection, resource_client, data):
         self.data = data
         self._connection = connection

--- a/simplivity/resources/omnistack_clusters.py
+++ b/simplivity/resources/omnistack_clusters.py
@@ -112,6 +112,8 @@ class OmnistackClusters(ResourceBase):
 class OmnistackCluster(object):
     """Implements features available for single OmniStack cluster resource."""
 
+    OBJECT_TYPE = 'omnistack_cluster'
+
     def __init__(self, connection, resource_client, data):
         self.data = data
         self._connection = connection

--- a/simplivity/resources/policies.py
+++ b/simplivity/resources/policies.py
@@ -18,6 +18,9 @@
 
 from simplivity.resources.resource import ResourceBase
 from simplivity.resources import virtual_machines
+from simplivity.resources.hosts import Host
+from simplivity.resources.omnistack_clusters import OmnistackCluster
+from simplivity.resources.cluster_groups import ClusterGroup
 
 URL = '/policies'
 DATA_FIELD = 'policies'
@@ -88,6 +91,26 @@ class Policies(ResourceBase):
 
         affected_object = self._client.do_post(URL, data, timeout, flags=flags)[0]
         return self.get_by_id(affected_object["object_id"])
+
+    def suspend(self, target=None, timeout=-1):
+        """Suspends policy-based backups on a specific targeted object
+            Args:
+                target: Target object.
+                        Allowed object of host, omnistack_cluster, cluster_group and default is federation
+                timeout: Time out for the request in seconds.
+
+            Returns:
+                None
+        """
+        data = {}
+        if isinstance(target, (Host, OmnistackCluster, ClusterGroup)):
+            data["target_object_type"] = target.OBJECT_TYPE
+            data["target_object_id"] = target.data["id"]
+        else:
+            data["target_object_type"] = 'federation'
+
+        resource_uri = "{}/suspend".format(URL)
+        self._client.do_post(resource_uri, data, timeout)
 
 
 class Policy(object):


### PR DESCRIPTION
Signed-off-by: Hemant Chaudhari <hchaudhari@hpe.com>

### Description
Add support to suspend the Simplivity policies

### Issues Resolved
None

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
