### PR TITLE
Add support for fetching time_zone on Omnistack Cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /hosts/{hostId}/remove_from_federation <POST>    
     - endpoint support for /hosts/{hostId}/hardware <GET>
     - endpoint support for /hosts/{hostId}/virtual_controller_shutdown_status <GET>
+    - endpoint support for /omnistack_clusters/time_zone_list <GET>
     - endpoint support for /policies <POST>
     - endpoint support for /policies/{policyId} <DELETE>
     - endpoint support for /policies/{policyId}/rules <POST>

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -26,6 +26,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/hosts/{hostId}/virtual_controller_shutdown_status  </sub>                          |GET      |
 |     **OmniStack Clusters**
 |<sub>/omnistack_clusters	</sub>                                                        |GET       |
+|<sub>/omnistack_clusters/time_zone_list  </sub>                                          |GET       |
 |     **Policies**
 |<sub>/policies	</sub>                                                                    |GET       |
 |<sub>/policies</sub>                                                                     |POST      |

--- a/examples/omnistack_clusters.py
+++ b/examples/omnistack_clusters.py
@@ -1,5 +1,5 @@
 ###
-# (C) Copyright [2019] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2019-2020] Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
 # limitations under the License.
 ##
 
+import pprint
+
 from simplivity.ovc_client import OVC
 from simplivity.exceptions import HPESimpliVityException
 
@@ -25,43 +27,54 @@ config = {
     }
 }
 
+pp = pprint.PrettyPrinter(indent=4)
+
 ovc = OVC(config)
 clusters = ovc.omnistack_clusters
 
-print("\n\n get_all with default params")
+print("\n\nget_all with default params")
 all_clusters = clusters.get_all()
 count = len(all_clusters)
 for cluster in all_clusters:
-    print(cluster.data)
+    print(f"{cluster}")
+    print(f"{pp.pformat(cluster.data)} \n")
 
-print("\nTotal number of clusterss {}".format(count))
+print("\n\nTotal number of clusters {}".format(count))
 cluster_object = all_clusters[0]
 
-print("\n\n get_all with filers")
+print("\n\nget_all with filers")
 all_clusters = clusters.get_all(filters={'name': cluster_object.data["name"]})
 count = len(all_clusters)
 for cluster in all_clusters:
-    print(cluster.data)
+    print(f"{cluster}")
+    print(f"{pp.pformat(cluster.data)} \n")
 
-print("\n Total number of clusters {}".format(count))
+print("\n\nTotal number of clusters {}".format(count))
 
-print("\n\n get_all with pagination")
+print("\n\nget_all with pagination")
 pagination = clusters.get_all(limit=105, pagination=True, page_size=50)
 end = False
 while not end:
     data = pagination.data
-    print("Page size:", len(data["resources"]))
-    print(data)
+    count = len(data["resources"])
+    print(f"Page size: {count}")
+    print(f"{pp.pformat(data)}")
 
     try:
         pagination.next_page()
     except HPESimpliVityException:
         end = True
 
-print("\n\n get_by_id")
+print("\n\nget_by_id")
 cluster = clusters.get_by_id(cluster_object.data["id"])
-print(cluster, cluster.data)
+print(f"{cluster}")
+print(f"{pp.pformat(cluster.data)} \n")
 
-print("\n\n get_by_name")
+print("\n\nget_by_name")
 cluster = clusters.get_by_name(cluster_object.data["name"])
-print(cluster, cluster.data)
+print(f"{cluster}")
+print(f"{pp.pformat(cluster.data)} \n")
+
+print("\n\nget_time_zone_list")
+time_zones = clusters.get_time_zone_list()
+print(f"{pp.pformat(time_zones)} \n")

--- a/simplivity/resources/omnistack_clusters.py
+++ b/simplivity/resources/omnistack_clusters.py
@@ -102,6 +102,12 @@ class OmnistackClusters(ResourceBase):
 
         return OmnistackCluster(self._connection, self._client, data)
 
+    def get_time_zone_list(self):
+        """Retrieves a list of all valid time zones"""
+
+        resource_uri = "{}/time_zone_list".format(URL)
+        return self._client.do_get(resource_uri)
+
 
 class OmnistackCluster(object):
     """Implements features available for single OmniStack cluster resource."""

--- a/tests/unit/resources/test_omnistack_clusters.py
+++ b/tests/unit/resources/test_omnistack_clusters.py
@@ -90,6 +90,16 @@ class OmnistackClustersTest(unittest.TestCase):
         self.assertIsInstance(obj, clusters.OmnistackCluster)
         self.assertEqual(obj.data, resource_data)
 
+    @mock.patch.object(Connection, "get")
+    def test_get_time_zones(self, mock_get):
+        resource_data = [
+            "America/Denver",
+            "America/New_York"
+        ]
+        mock_get.return_value = resource_data
+        time_zones = self.clusters.get_time_zone_list()
+        self.assertEqual(time_zones, resource_data)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Hemant Chaudhari <hchaudhari@hpe.com>

### Description
Add support for fetching time_zone on Omnistack Cluster
### Issues Resolved
None
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
