### PR TITLE
Add support for the omnistack cluster connected clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /hosts/{hostId}/hardware <GET>
     - endpoint support for /hosts/{hostId}/virtual_controller_shutdown_status <GET>
     - endpoint support for /omnistack_clusters/time_zone_list <GET>
+    - endpoint support for /omnistack_clusters/{clusterId}/connected_clusters  <GET>
     - endpoint support for /policies <POST>
     - endpoint support for /policies/{policyId} <DELETE>
     - endpoint support for /policies/{policyId}/rules <POST>

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -29,6 +29,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |     **OmniStack Clusters**
 |<sub>/omnistack_clusters	</sub>                                                        |GET       |
 |<sub>/omnistack_clusters/time_zone_list  </sub>                                          |GET       |
+|<sub>/omnistack_clusters/{clusterId}/connected_clusters  </sub>                          |GET       |
 |     **Policies**
 |<sub>/policies	</sub>                                                                    |GET       |
 |<sub>/policies</sub>                                                                     |POST      |

--- a/examples/omnistack_clusters.py
+++ b/examples/omnistack_clusters.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ##
-
 import pprint
 
 from simplivity.ovc_client import OVC
@@ -31,6 +30,9 @@ pp = pprint.PrettyPrinter(indent=4)
 
 ovc = OVC(config)
 clusters = ovc.omnistack_clusters
+
+# variable declaration
+cluster_1_name = "cluster1"
 
 print("\n\nget_all with default params")
 all_clusters = clusters.get_all()
@@ -78,3 +80,8 @@ print(f"{pp.pformat(cluster.data)} \n")
 print("\n\nget_time_zone_list")
 time_zones = clusters.get_time_zone_list()
 print(f"{pp.pformat(time_zones)} \n")
+
+print("\n\nget_connected_clusters")
+cluster1 = clusters.get_by_name(cluster_1_name)
+connected_clusters = cluster1.get_connected_clusters()
+print(f"{pp.pformat(connected_clusters)} \n")

--- a/simplivity/resources/omnistack_clusters.py
+++ b/simplivity/resources/omnistack_clusters.py
@@ -116,3 +116,17 @@ class OmnistackCluster(object):
         self.data = data
         self._connection = connection
         self._client = resource_client
+        self._clusters = OmnistackClusters(self._connection)
+
+    def get_connected_clusters(self):
+        """Retrieves directly connected omnistack_clusters.
+
+        Returns:
+            list: List of omnistack_clusters objects.
+        """
+        method_url = "{}/{}/connected_clusters".format(URL, self.data["id"])
+        connected_clusters = self._client.do_get(method_url).get("omnistack_clusters", [])
+
+        clusters = [self._clusters.get_by_id(cluster["id"]) for cluster in connected_clusters]
+
+        return clusters

--- a/tests/unit/resources/test_omnistack_clusters.py
+++ b/tests/unit/resources/test_omnistack_clusters.py
@@ -16,6 +16,7 @@
 
 import unittest
 from unittest import mock
+from unittest.mock import call
 
 from simplivity.connection import Connection
 from simplivity import exceptions
@@ -99,6 +100,17 @@ class OmnistackClustersTest(unittest.TestCase):
         mock_get.return_value = resource_data
         time_zones = self.clusters.get_time_zone_list()
         self.assertEqual(time_zones, resource_data)
+
+    @mock.patch.object(Connection, "get")
+    def test_get_connected_clusters(self, mock_get):
+        mock_get.side_effect = [{'omnistack_clusters': [{'id': '12345'}]}, {'omnistack_clusters': [{'id': '12345'}]}]
+
+        cluster_data = {'name': 'name1', 'id': '12345'}
+        cluster = self.clusters.get_by_data(cluster_data)
+        obj = cluster.get_connected_clusters()
+        self.assertIsInstance(obj[0], clusters.OmnistackCluster)
+        mock_get.assert_has_calls([call('/omnistack_clusters/12345/connected_clusters'),
+                                  call('/omnistack_clusters?case=sensitive&id=12345&limit=500&offset=0&order=descending&sort=name')])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Signed-off-by: KalpanaBhardwaj <bhardwaj@hpe.com>

### Description
Add support for the omnistack cluster connected clusters

### Issues Resolved
None

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
