### PR TITLE
Add support to set the time zone on Omnistack Cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /hosts/{hostId}/virtual_controller_shutdown_status <GET>
     - endpoint support for /omnistack_clusters/time_zone_list <GET>
     - endpoint support for /omnistack_clusters/{clusterId}/connected_clusters  <GET>
+    - endpoint support for /omnistack_clusters/{clusterId}/set_time_zone <POST>
     - endpoint support for /policies <POST>
     - endpoint support for /policies/suspend <POST>
     - endpoint support for /policies/{policyId} <DELETE>

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -31,6 +31,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/omnistack_clusters	</sub>                                                        |GET       |
 |<sub>/omnistack_clusters/time_zone_list  </sub>                                          |GET       |
 |<sub>/omnistack_clusters/{clusterId}/connected_clusters  </sub>                          |GET       |
+|<sub>/omnistack_clusters/{clusterId}/set_time_zone </sub>                                |POST      |
 |     **Policies**
 |<sub>/policies	</sub>                                                                    |GET       |
 |<sub>/policies</sub>                                                                     |POST      |

--- a/examples/omnistack_clusters.py
+++ b/examples/omnistack_clusters.py
@@ -44,7 +44,7 @@ for cluster in all_clusters:
 print("\n\nTotal number of clusters {}".format(count))
 cluster_object = all_clusters[0]
 
-print("\n\nget_all with filers")
+print("\n\nget_all with filters")
 all_clusters = clusters.get_all(filters={'name': cluster_object.data["name"]})
 count = len(all_clusters)
 for cluster in all_clusters:
@@ -85,3 +85,13 @@ print("\n\nget_connected_clusters")
 cluster1 = clusters.get_by_name(cluster_1_name)
 connected_clusters = cluster1.get_connected_clusters()
 print(f"{pp.pformat(connected_clusters)} \n")
+cluster = clusters.get_all(show_optional_fields=True,
+                           filters={'id': cluster.data["id"]})[0]
+ori_time_zone = cluster.data['time_zone']
+
+print("\n\nset_time_zone")
+cluster = cluster.set_time_zone("Zulu")
+print(f"{pp.pformat(cluster.data)} \n")
+# revert to original time zone
+cluster = cluster.set_time_zone(ori_time_zone)
+print(f"{pp.pformat(cluster.data)} \n")

--- a/simplivity/resources/omnistack_clusters.py
+++ b/simplivity/resources/omnistack_clusters.py
@@ -112,7 +112,7 @@ class OmnistackClusters(ResourceBase):
 class OmnistackCluster(object):
     """Implements features available for single OmniStack cluster resource."""
 
-    OBJECT_TYPE = 'omnistack_cluster'
+    OBJECT_TYPE = "omnistack_cluster"
 
     def __init__(self, connection, resource_client, data):
         self.data = data
@@ -132,3 +132,26 @@ class OmnistackCluster(object):
         clusters = [self._clusters.get_by_id(cluster["id"]) for cluster in connected_clusters]
 
         return clusters
+
+    def __refresh(self):
+        """Updates the omnistack cluster data."""
+        resource_uri = "{}/{}".format(URL, self.data["id"])
+        self.data = self._client.do_get(resource_uri)[self.OBJECT_TYPE]
+
+    def set_time_zone(self, time_zone, timeout=-1):
+        """ Sets the time zone for a cluster.
+
+        Args:
+            time_zone: The time zone in case-sensitive region/locale format
+                       for example, "America/New_York"
+            timeout : Time out for the request in seconds.
+
+        Returns:
+            object: omnistack cluster object.
+        """
+
+        method_url = "{}/{}/set_time_zone".format(URL, self.data["id"])
+        data = {"time_zone": time_zone}
+        self._client.do_post(method_url, data, timeout)
+        self.__refresh()
+        return self

--- a/tests/unit/resources/test_omnistack_clusters.py
+++ b/tests/unit/resources/test_omnistack_clusters.py
@@ -112,6 +112,18 @@ class OmnistackClustersTest(unittest.TestCase):
         mock_get.assert_has_calls([call('/omnistack_clusters/12345/connected_clusters'),
                                   call('/omnistack_clusters?case=sensitive&id=12345&limit=500&offset=0&order=descending&sort=name')])
 
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_set_time_zone(self, mock_get, mock_post):
+        resource_data = {'id': '12345', 'name': 'name1', 'time_zone': 'Zulu'}
+        mock_get.return_value = {'omnistack_cluster': {'id': '12345', 'name': 'name1', 'time_zone': 'Africa/Accra'}}
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        cluster = self.clusters.get_by_data(resource_data)
+        cluster_obj = cluster.set_time_zone("Africa/Accra")
+        self.assertEqual(cluster_obj.data['time_zone'], "Africa/Accra")
+        data = {'time_zone': 'Africa/Accra'}
+        mock_post.assert_called_once_with('/omnistack_clusters/12345/set_time_zone', data, custom_headers=None)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Vansh Verma <vansh.verma@hpe.com>

### Description
Add support to set the time zone on Omnistack Cluster

### Issues Resolved
None

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
