### PR TITLE
Add support for cancel shutdown for virtual controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /datastore/{datastoreId} <DELETE>
     - endpoint support for /datastore/{datastoreId}/resize <POST>
     - endpoint support for /datastore/{datastoreId}/set_policy <POST>
+    - endpoint support for /hosts/{hostId}/cancel_virtual_controller_shutdown <POST>
     - endpoint support for /hosts/{hostId}/remove_from_federation <POST>    
     - endpoint support for /hosts/{hostId}/shutdown_virtual_controller <POST>
     - endpoint support for /hosts/{hostId}/hardware <GET>

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -21,6 +21,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/datastores/{datastoreId}/set_policy  </sub>                                        |POST      |
 |     **Hosts**
 |<sub>/hosts	</sub>                                                                    |GET       |
+|<sub>/hosts/{hostId}/cancel_virtual_controller_shutdown </sub>                 	  |POST      |
 |<sub>/hosts/{hostId}/remove_from_federation  </sub>						|POST      |
 |<sub>/hosts/{hostId}/hardware  </sub>						          |GET      |
 |<sub>/hosts/{hostId}/virtual_controller_shutdown_status  </sub>                          |GET      |

--- a/examples/hosts.py
+++ b/examples/hosts.py
@@ -87,3 +87,8 @@ host = hosts.get_by_id(host_object.data["id"])
 response = host.shutdown_virtual_controller()
 print("\n\nshutdown virtual controller status : {}".format(response))
 print("\n\nplease power on the virtual controller manually")
+
+print("\n\ncancel virtual controller shutdown")
+host = hosts.get_by_id(host_object.data["id"])
+response = host.cancel_virtual_controller_shutdown()
+print("\n\nvirtual controller cancellation status : {}".format(response))

--- a/simplivity/resources/hosts.py
+++ b/simplivity/resources/hosts.py
@@ -200,3 +200,16 @@ class Host(object):
 
         status = self._client.do_post(method_url, data, timeout)
         return status['shutdown_status']['status']
+
+    def cancel_virtual_controller_shutdown(self, timeout=-1):
+        """Cancels the virtual controller shutdown.
+
+        Args:
+          timeout: Time out for the request in seconds.
+
+        Returns:
+          status: Possible values are 'SUCCESS', 'FAILURE', 'UNKNOWN', 'IN_PROGRESS'.
+        """
+        resource_uri = "{}/{}/cancel_virtual_controller_shutdown".format(URL, self.data["id"])
+        status = self._client.do_post(resource_uri, None, timeout)
+        return status['cancellation_status']['status']

--- a/tests/unit/resources/test_hosts.py
+++ b/tests/unit/resources/test_hosts.py
@@ -167,6 +167,17 @@ class HostsTest(unittest.TestCase):
         mock_post.assert_called_once_with("/hosts/12345/shutdown_virtual_controller",
                                           {"ha_wait": False}, custom_headers=None)
 
+    @mock.patch.object(Connection, "post")
+    def test_cancel_virtual_controller_shutdown(self, mock_post):
+        mock_post.return_value = None, {'cancellation_status': {'status': 'SUCCESS'}}
+        host_data = {"id": "12345"}
+        host = self.hosts.get_by_data(host_data)
+
+        response = host.cancel_virtual_controller_shutdown()
+        self.assertEqual(response, "SUCCESS")
+        mock_post.assert_called_once_with("/hosts/12345/cancel_virtual_controller_shutdown", None,
+                                          custom_headers=None)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Vansh Verma <vansh.verma@hpe.com>

### Description
Add support for cancel shutdown for virtual controller

### Issues Resolved
None

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
