### PR TITLE
Fixing issue get virtual_controller_shutdown_status to return string as status

### DIFF
--- a/examples/hosts.py
+++ b/examples/hosts.py
@@ -80,7 +80,7 @@ print(f"{pp.pformat(host_hardware)} \n")
 
 print("\n\nget virtual controller shutdown status")
 virtual_controller_status = host.get_virtual_controller_shutdown_status()
-print(f"{pp.pformat(virtual_controller_status)} \n")
+print("\n\nvirtual controller shutdown status : {}".format(virtual_controller_status))
 
 print("\n\nshutdown virtual controller")
 host = hosts.get_by_id(host_object.data["id"])

--- a/simplivity/resources/hosts.py
+++ b/simplivity/resources/hosts.py
@@ -179,7 +179,8 @@ class Host(object):
     def get_virtual_controller_shutdown_status(self):
         """Retrieves the shutdown status of the Virtual Controller"""
         resource_uri = "{}/{}/virtual_controller_shutdown_status".format(URL, self.data["id"])
-        return self._client.do_get(resource_uri)
+        status = self._client.do_get(resource_uri)
+        return status['shutdown_status']['status']
 
     def shutdown_virtual_controller(self, ha_wait=True, timeout=-1):
         """Shuts down the Virtual Controller safely (by reaching HA compliance) or by force.

--- a/tests/unit/resources/test_hosts.py
+++ b/tests/unit/resources/test_hosts.py
@@ -144,7 +144,7 @@ class HostsTest(unittest.TestCase):
         host = self.hosts.get_by_data(host_data)
 
         virtual_controller_status = host.get_virtual_controller_shutdown_status()
-        self.assertEqual(virtual_controller_status, resource_data)
+        self.assertEqual(virtual_controller_status, 'NONE')
 
     @mock.patch.object(Connection, "post")
     def test_shutdown_virtual_controller_ha_wait(self, mock_post):


### PR DESCRIPTION
Signed-off-by: Hemant Chaudhari <hchaudhari@hpe.com>

### Description
Fixing issue get virtual_controller_shutdown_status to return string as status

### Issues Resolved
Fixes #46 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
