### PR TITLE
Add support for SimpliVity backup lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
     - endpoint support for /backups/delete <POST>
     - endpoint support for /backups/{bkpId} <DELETE>
+    - endpoint support for /backups/{bkpId}/lock <POST>
     - endpoint support for /backups/{bkpId}/restore <POST>
     - endpoint support for /cluster_groups <GET>
     - endpoint support for /datastore <POST>

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -10,6 +10,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/backups	</sub>                                                                    |GET       |
 |<sub>/backups/delete  </sub>                                                             |POST      |
 |<sub>/backups/{bkpId}  </sub>                                                            |DELETE    |
+|<sub>/backups/{bkpId}/lock</sub>                                                            |POST    |
 |<sub>/backups/{bkpId}/restore  </sub>                                                    |POST      |
 |     **Cluster Groups**
 |<sub>/cluster_groups  </sub>                                                             |GET       |

--- a/examples/backups.py
+++ b/examples/backups.py
@@ -81,7 +81,7 @@ print(f"{pp.pformat(backup.data)} \n")
 
 print("Create backup for the testing the restore functionality")
 vm = machines.get_by_name(test_vm_name)
-backup = vm.create_backup("backup_test_from_sdk_" + str(time.time()))
+backup = vm.create_backup("backup_test_from_sdk_" + str(time.time()), retention=120)
 print(f"{backup}")
 print(f"{pp.pformat(backup.data)} \n")
 
@@ -110,5 +110,10 @@ print(f"{pp.pformat(restored_vm.data)} \n")
 restored_vm = backup.restore(False, "Restored_Machine_SDK_anotherDS_Name", datastore_object.data["name"])
 print(f"{restored_vm}")
 print(f"{pp.pformat(restored_vm.data)} \n")
+
+print("\n\nsaves the specified backup to prevent it from expiring, verify: expiration_time set to NA")
+backup.lock()
+print(f"{backup}")
+print(f"{pp.pformat(backup.data)} \n")
 
 backup.delete()

--- a/simplivity/resources/backups.py
+++ b/simplivity/resources/backups.py
@@ -148,6 +148,12 @@ class Backup(object):
         self.data = data
         self._connection = connection
         self._client = resource_client
+        self._backups = Backups(self._connection)
+
+    def __refresh(self):
+        """Updates the backup data."""
+        resource_object = self._backups.get_by_id(self.data["id"])
+        self.data = resource_object.data
 
     def delete(self, timeout=-1):
         """Deletes the specified backup"""
@@ -184,3 +190,11 @@ class Backup(object):
         affected_object = self._client.do_post(resource_uri, data, timeout, None, flags)[0]
         virtual_machines_obj = virtual_machines.VirtualMachines(self._connection)
         return virtual_machines_obj.get_by_id(affected_object["object_id"])
+
+    def lock(self, timeout=-1):
+        """Saves the specified backup to prevent it from expiring"""
+        resource_uri = "{}/{}/lock".format(URL, self.data["id"])
+        self._client.do_post(resource_uri, None, timeout)
+        self.__refresh()
+
+        return self

--- a/tests/unit/resources/test_backups.py
+++ b/tests/unit/resources/test_backups.py
@@ -165,6 +165,19 @@ class BackupTest(unittest.TestCase):
         data = {'virtual_machine_name': 'vm1', 'datastore_id': 'abcdef'}
         mock_post.assert_called_once_with('/backups/12345/restore?restore_original=False', data, custom_headers=None)
 
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_lock(self, mock_get, mock_post):
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        resource_data = {'name': 'name1', 'id': '12345', 'expiration_time': 'NA'}
+        mock_get.return_value = {backups.DATA_FIELD: [resource_data]}
+        backup_data = {'name': 'name1', 'id': '12345', 'expiration_time': '2020-05-17T03:59:32Z'}
+        backup = self.backups.get_by_data(backup_data)
+        backup_obj = backup.lock()
+        self.assertEqual(backup_obj.data, resource_data)
+
+        mock_post.assert_called_once_with('/backups/12345/lock', None, custom_headers=None)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Hemant Chaudhari <hchaudhari@hpe.com>

### Description
Add support for SimpliVity backup lock

### Issues Resolved
None

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
