### PR TITLE
Add support to rename the SimpliVity policy name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /omnistack_clusters/time_zone_list <GET>
     - endpoint support for /policies <POST>
     - endpoint support for /policies/{policyId} <DELETE>
+    - endpoint support for /policies/{policyId}/rename <POST>
     - endpoint support for /policies/{policyId}/rules <POST>
     - endpoint support for /policies/{policyId}/rules/{ruleId} <GET>
     - endpoint support for /policies/{policyId}/rules/{ruleId} <DELETE>

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -33,6 +33,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/policies	</sub>                                                                    |GET       |
 |<sub>/policies</sub>                                                                     |POST      |
 |<sub>/policies/{policyId} </sub>                                                         |DELETE    |
+|<sub>/policies/{policyId}/rename</sub>                                                   |POST      |
 |<sub>/policies/{policyId}/rules </sub>                                                   |POST      |
 |<sub>/policies/{policyId}/rules/{ruleId} </sub>                                          |GET       |
 |<sub>/policies/{policyId}/rules/{ruleId} </sub>                                          |DELETE    |

--- a/examples/policies.py
+++ b/examples/policies.py
@@ -123,5 +123,10 @@ policy.delete_rule(rule_id)
 print(f"{policy}")
 print(f"{pp.pformat(policy.data)} \n")
 
+print("\n\nrename policy")
+policy.rename(f"renamed_{policy.data['name']}")
+print(f"{policy}")
+print(f"{pp.pformat(policy.data)} \n")
+
 print("\n\ndelete policy")
 policy.delete()

--- a/simplivity/resources/policies.py
+++ b/simplivity/resources/policies.py
@@ -199,3 +199,21 @@ class Policy(object):
         """
         resource_uri = "{}/{}/rules/{}".format(URL, self.data["id"], rule_id)
         return self._client.do_get(resource_uri)
+
+    def rename(self, name, timeout=-1):
+        """Renames the specified policy
+        Args:
+            name: The new name of the specified policy.
+            timeout: Time out for the request in seconds.
+
+        Returns:
+            object: Policy object.
+        """
+
+        resource_uri = "{}/{}/rename".format(URL, self.data["id"])
+
+        data = {'name': name}
+        self._client.do_post(resource_uri, data, timeout)
+        self.__refresh()
+
+        return self

--- a/tests/unit/resources/test_policies.py
+++ b/tests/unit/resources/test_policies.py
@@ -232,6 +232,21 @@ class PoliciesTest(unittest.TestCase):
         self.assertEqual(response_policy.data, resources_data)
         mock_delete.assert_called_once_with('/policies/67890/rules/12345', custom_headers=None)
 
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_rename(self, mock_get, mock_post):
+        resource_data = {'name': 'policy0', 'id': '12345'}
+        policy = self.policies.get_by_data(resource_data)
+        policy_data = {'name': 'renamed_policy0', 'id': '12345'}
+        mock_get.return_value = {'policy': policy_data}
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        policy = policy.rename(policy_data['name'])
+        self.assertIsInstance(policy, policies.Policy)
+        self.assertEqual(policy.data["name"], policy_data['name'])
+        mock_post.assert_called_once_with('/policies/12345/rename',
+                                          {'name': policy_data['name']},
+                                          custom_headers=None)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Hemant Chaudhari <hchaudhari@hpe.com>

### Description
Add support to rename the SimpliVity policy name

### Issues Resolved
None

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
