### PR TITLE
Add support for rename of Simplivity backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /backups/delete <POST>
     - endpoint support for /backups/{bkpId} <DELETE>
     - endpoint support for /backups/{bkpId}/lock <POST>
+    - endpoint support for /backups/{bkpId}/rename <POST>
     - endpoint support for /backups/{bkpId}/restore <POST>
     - endpoint support for /cluster_groups <GET>
     - endpoint support for /datastore <POST>

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -11,6 +11,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/backups/delete  </sub>                                                             |POST      |
 |<sub>/backups/{bkpId}  </sub>                                                            |DELETE    |
 |<sub>/backups/{bkpId}/lock</sub>                                                            |POST    |
+|<sub>/backups/{bkpId}/rename</sub>                                                       |POST      |
 |<sub>/backups/{bkpId}/restore  </sub>                                                    |POST      |
 |     **Cluster Groups**
 |<sub>/cluster_groups  </sub>                                                             |GET       |

--- a/examples/backups.py
+++ b/examples/backups.py
@@ -116,4 +116,10 @@ backup.lock()
 print(f"{backup}")
 print(f"{pp.pformat(backup.data)} \n")
 
+print("\n\nrename the backup")
+backup.rename(f"renamed_{backup.data['name']}")
+print(f"{backup}")
+print(f"{pp.pformat(backup.data)} \n")
+
+
 backup.delete()

--- a/simplivity/resources/backups.py
+++ b/simplivity/resources/backups.py
@@ -198,3 +198,20 @@ class Backup(object):
         self.__refresh()
 
         return self
+
+    def rename(self, new_name, timeout=-1):
+        """Renames the specified backup
+        Args:
+            new_name: The new name for the backup.
+            timeout: Time out for the request in seconds.
+
+        Returns:
+            object: Backup object.
+        """
+
+        resource_uri = "{}/{}/rename".format(URL, self.data["id"])
+        data = {'backup_name': new_name}
+        self._client.do_post(resource_uri, data, timeout)
+        self.__refresh()
+
+        return self

--- a/tests/unit/resources/test_backups.py
+++ b/tests/unit/resources/test_backups.py
@@ -178,6 +178,21 @@ class BackupTest(unittest.TestCase):
 
         mock_post.assert_called_once_with('/backups/12345/lock', None, custom_headers=None)
 
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_rename(self, mock_get, mock_post):
+        resource_data = {'name': 'backup1', 'id': '12345'}
+        backup = self.backups.get_by_data(resource_data)
+        backup_data = {'name': 'renamed_backup1', 'id': '12345'}
+        mock_get.return_value = {backups.DATA_FIELD: [backup_data]}
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        backup_obj = backup.rename(backup_data['name'])
+        self.assertIsInstance(backup_obj, backups.Backup)
+        self.assertEqual(backup_obj.data["name"], backup_data['name'])
+        mock_post.assert_called_once_with('/backups/12345/rename',
+                                          {'backup_name': backup_data['name']},
+                                          custom_headers=None)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Hemant Chaudhari <hchaudhari@hpe.com>

### Description
Add support for rename of Simplivity backup

### Issues Resolved
None

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
