### PR TITLE
Add support to edit the Simplivity policy rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /policies/{policyId}/rules <POST>
     - endpoint support for /policies/{policyId}/rules/{ruleId} <GET>
     - endpoint support for /policies/{policyId}/rules/{ruleId} <DELETE>
+    - endpoint support for /policies/{policyId}/rules/{ruleId} <PUT>
     - endpoint support for /virtual_machines/{vmId}/power_off <POST>
     - endpoint support for /virtual_machines/{vmId}/power_on <POST>
     - missing ovc client host unit tests to improve code coverage

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -43,6 +43,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/policies/{policyId}/rules </sub>                                                   |POST      |
 |<sub>/policies/{policyId}/rules/{ruleId} </sub>                                          |GET       |
 |<sub>/policies/{policyId}/rules/{ruleId} </sub>                                          |DELETE    |
+|<sub>/policies/{policyId}/rules/{ruleId}</sub>                                           |PUT       |
 |     **Virtual Machines**
 |<sub>/virtual_machines	</sub>                                                            |GET       |
 |<sub>/virtual_machines/set_policy	</sub>                                                |POST      |

--- a/examples/policies.py
+++ b/examples/policies.py
@@ -120,8 +120,17 @@ for rule in all_rules:
     rule_obj = policy.get_rule(rule.get('id'))
     print(f"{pp.pformat(rule_obj)} \n")
 
-print("\n\ndelete rule")
+print("\n\nedit rule")
+updated_rule = {
+    "start_time": "16:30",
+    "end_time": "18:30"
+}
 rule_id = policy.data["rules"][0]['id']
+policy.edit_rule(rule_id, updated_rule)
+print(f"{policy}")
+print(f"{pp.pformat(policy.data)} \n")
+
+print("\n\ndelete rule")
 policy.delete_rule(rule_id)
 print(f"{policy}")
 print(f"{pp.pformat(policy.data)} \n")

--- a/simplivity/resources/policies.py
+++ b/simplivity/resources/policies.py
@@ -262,3 +262,42 @@ class Policy(object):
         self.__refresh()
 
         return self
+
+    def edit_rule(self, rule_id, rule, timeout=-1):
+        """Edits an existing policy rule
+        Args:
+            rule_id: Rule id to be edited
+            rule: Dictionary of fields from backup policy rule can change, except destination_name, id, number,
+                  and max_backups.
+                application_consistent: Set false for crash-consistent backups
+                                        Set true for application-consistent backups (for example, VSS or snapshot backups)
+                                        Default: false
+                consistency_type: Set to DEFAULT for a snapshot backup
+                                  Set to VSS for a Microsoft Volume Shadow Copy Service backup
+                                  Set to NONE for crash-consistent backups
+                                  Default: NONE
+                destination_id: The unique identifier (UID) of the omnistack_cluster to store the backup
+                                Default: local omnistack_cluster
+                days: The days of the week (for example, Mon,Fri), or month (for example, 1,15) to take backups or
+                      "last" to specify the last day of each month
+                      Default: All (that is, every day)
+                frequency: The number of minutes between backups
+                retention: The number of minutes to keep backups
+                start_time: The time to start the backups, for example, 14:30
+                            This time is local to the time zone of the Hypervisor Management System (HMS)
+                            Default: 00:00
+                end_time: The time to stop backing up, for example, 14:30
+                          This time is local to the time zone of the Hypervisor Management System (HMS)
+                          Default: 00:00
+                external_store_name: The name of the external_store
+
+            timeout: Time out for the request in seconds.
+
+        Returns:
+            self: Returns the policy object.
+        """
+        resource_uri = "{}/{}/rules/{}".format(URL, self.data["id"], rule_id)
+        self._client.do_put(resource_uri, rule, timeout)
+        self.__refresh()
+
+        return self

--- a/tests/unit/resources/test_policies.py
+++ b/tests/unit/resources/test_policies.py
@@ -330,6 +330,21 @@ class PoliciesTest(unittest.TestCase):
                 'target_object_type': 'cluster_group'}
         mock_post.assert_called_once_with('/policies/resume', data, custom_headers=None)
 
+    @mock.patch.object(Connection, "put")
+    @mock.patch.object(Connection, "get")
+    def test_edit_rule(self, mock_get, mock_put):
+        mock_put.return_value = None, [{'object_id': '67890'}]
+        updated_rule = {'frequency': 10, 'retention': 50}
+        resources_data = {"rules": [updated_rule], "name": "policy1", "id": "67890"}
+        mock_get.return_value = {'policy': resources_data}
+        policy_data = {"rules": [{"frequency": 5, "id": "12345", "retention": 1}], "name": "policy1",
+                       "id": "67890"}
+        policy = self.policies.get_by_data(policy_data)
+
+        response_policy = policy.edit_rule(12345, updated_rule)
+        self.assertEqual(response_policy.data, resources_data)
+        mock_put.assert_called_once_with('/policies/67890/rules/12345', updated_rule, custom_headers=None)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Hemant Chaudhari <hchaudhari@hpe.com>

### Description
Add support to edit the Simplivity policy rule

### Issues Resolved
None

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
