### PR TITLE
Add support for set retention on simplivity backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /hosts/{hostId}/virtual_controller_shutdown_status <GET>
     - endpoint support for /omnistack_clusters/time_zone_list <GET>
     - endpoint support for /omnistack_clusters/{clusterId}/connected_clusters  <GET>
+    - endpoint support for /omnistack_clusters/{clusterId}/set_time_zone <POST>
     - endpoint support for /policies <POST>
     - endpoint support for /policies/suspend <POST>
     - endpoint support for /policies/{policyId} <DELETE>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
     - endpoint support for /backups/delete <POST>
+    - endpoint support for /backups/set_retention <POST>
     - endpoint support for /backups/{bkpId} <DELETE>
     - endpoint support for /backups/{bkpId}/lock <POST>
     - endpoint support for /backups/{bkpId}/restore <POST>

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -31,6 +31,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/omnistack_clusters	</sub>                                                        |GET       |
 |<sub>/omnistack_clusters/time_zone_list  </sub>                                          |GET       |
 |<sub>/omnistack_clusters/{clusterId}/connected_clusters  </sub>                          |GET       |
+|<sub>/omnistack_clusters/{clusterId}/set_time_zone </sub>                                |POST      |
 |     **Policies**
 |<sub>/policies	</sub>                                                                    |GET       |
 |<sub>/policies</sub>                                                                     |POST      |

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -9,6 +9,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |     **Backups**
 |<sub>/backups	</sub>                                                                    |GET       |
 |<sub>/backups/delete  </sub>                                                             |POST      |
+|<sub>/backups/set_retention</sub>                                                        |POST      |
 |<sub>/backups/{bkpId}  </sub>                                                            |DELETE    |
 |<sub>/backups/{bkpId}/lock</sub>                                                            |POST    |
 |<sub>/backups/{bkpId}/restore  </sub>                                                    |POST      |

--- a/examples/backups.py
+++ b/examples/backups.py
@@ -117,3 +117,21 @@ print(f"{backup}")
 print(f"{pp.pformat(backup.data)} \n")
 
 backup.delete()
+
+print("\n\nset retention")
+vm = machines.get_by_name(test_vm_name)
+backup1 = vm.create_backup("backup_test_from_sdk_set_retention1_" + str(time.time()))
+print(f"{backup1}")
+print(f"{pp.pformat(backup1.data)} \n")
+backup2 = vm.create_backup("backup_test_from_sdk_set_retention2_" + str(time.time()))
+print(f"{backup2}")
+print(f"{pp.pformat(backup2.data)} \n")
+
+backup_list = [backup1, backup2]
+backup_obj = backups.set_retention(backup_list, 10)
+
+for backup in backup_obj:
+    print(f"{backup}")
+    print(f"{pp.pformat(backup.data)} \n")
+
+backups.delete_multiple_backups(backup_list)

--- a/examples/omnistack_clusters.py
+++ b/examples/omnistack_clusters.py
@@ -44,7 +44,7 @@ for cluster in all_clusters:
 print("\n\nTotal number of clusters {}".format(count))
 cluster_object = all_clusters[0]
 
-print("\n\nget_all with filers")
+print("\n\nget_all with filters")
 all_clusters = clusters.get_all(filters={'name': cluster_object.data["name"]})
 count = len(all_clusters)
 for cluster in all_clusters:
@@ -85,3 +85,13 @@ print("\n\nget_connected_clusters")
 cluster1 = clusters.get_by_name(cluster_1_name)
 connected_clusters = cluster1.get_connected_clusters()
 print(f"{pp.pformat(connected_clusters)} \n")
+cluster = clusters.get_all(show_optional_fields=True,
+                           filters={'id': cluster.data["id"]})[0]
+
+print("\n\nset_time_zone")
+ori_time_zone = cluster.data['time_zone']
+cluster = cluster.set_time_zone("Zulu")
+print(f"{pp.pformat(cluster.data)} \n")
+# revert to original time zone
+cluster = cluster.set_time_zone(ori_time_zone)
+print(f"{pp.pformat(cluster.data)} \n")

--- a/simplivity/resources/omnistack_clusters.py
+++ b/simplivity/resources/omnistack_clusters.py
@@ -120,6 +120,11 @@ class OmnistackCluster(object):
         self._client = resource_client
         self._clusters = OmnistackClusters(self._connection)
 
+    def __refresh(self):
+        """Updates the omnistack cluster data."""
+        resource_uri = "{}/{}".format(URL, self.data["id"])
+        self.data = self._client.do_get(resource_uri)[self.OBJECT_TYPE]
+
     def get_connected_clusters(self):
         """Retrieves directly connected omnistack_clusters.
 
@@ -132,3 +137,21 @@ class OmnistackCluster(object):
         clusters = [self._clusters.get_by_id(cluster["id"]) for cluster in connected_clusters]
 
         return clusters
+
+    def set_time_zone(self, time_zone, timeout=-1):
+        """ Sets the time zone for a cluster.
+
+        Args:
+            time_zone: The time zone in case-sensitive region/locale format
+                       for example, "America/New_York"
+            timeout : Time out for the request in seconds.
+
+        Returns:
+            object: omnistack cluster object.
+        """
+
+        method_url = "{}/{}/set_time_zone".format(URL, self.data["id"])
+        data = {"time_zone": time_zone}
+        self._client.do_post(method_url, data, timeout)
+        self.__refresh()
+        return self

--- a/tests/unit/resources/test_backups.py
+++ b/tests/unit/resources/test_backups.py
@@ -22,6 +22,7 @@ from simplivity import exceptions
 from simplivity.resources import backups
 from simplivity.resources import datastores
 from simplivity.resources import virtual_machines
+from simplivity.resources import cluster_groups
 
 
 class BackupTest(unittest.TestCase):
@@ -31,6 +32,7 @@ class BackupTest(unittest.TestCase):
         self.backups = backups.Backups(self.connection)
         self.datastores = datastores.Datastores(self.connection)
         self.virtual_machines = virtual_machines.VirtualMachines(self.connection)
+        self.cluster_groups = cluster_groups.ClusterGroups(self.connection)
 
     @mock.patch.object(Connection, "get")
     def test_get_all_returns_resource_obj(self, mock_get):
@@ -177,6 +179,114 @@ class BackupTest(unittest.TestCase):
         self.assertEqual(backup_obj.data, resource_data)
 
         mock_post.assert_called_once_with('/backups/12345/lock', None, custom_headers=None)
+
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_set_retention_force_false_cluster_obj(self, mock_get, mock_post):
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        backup_data = [{'name': 'name1', 'id': '12345', 'expiration_time': 'NA'},
+                       {'name': 'name2', 'id': '67890', 'expiration_time': 'NA'}]
+        backup_ret_data = [{'name': 'name1', 'id': '12345', 'expiration_time': '2020-05-22T15:51:56Z'},
+                           {'name': 'name2', 'id': '67890', 'expiration_time': '2020-05-22T15:51:56Z'}]
+        backup_list = [self.backups.get_by_data(entry) for entry in backup_data]
+        backup_ids = [backup.data['id'] for backup in backup_list]
+        cluster_group_data = {"id": "12345", 'name': 'cluster_group1'}
+        cluster_group = self.cluster_groups.get_by_data(cluster_group_data)
+        mock_get.return_value = {backups.DATA_FIELD: backup_ret_data}
+        backup_obj = self.backups.set_retention(backup_list, 10, False, cluster_group)
+        self.assertIsInstance(backup_obj[0], backups.Backup)
+        self.assertEqual(backup_obj[0].data, backup_ret_data[0])
+        data = {'backup_id': backup_ids, 'retention': 10, 'force': False, 'cluster_group_id': "12345"}
+        mock_post.assert_called_once_with('/backups/set_retention', data, custom_headers=None)
+
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_set_retention_force_true_cluster_obj(self, mock_get, mock_post):
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        backup_data = [{'name': 'name1', 'id': '12345', 'expiration_time': 'NA'},
+                       {'name': 'name2', 'id': '67890', 'expiration_time': 'NA'}]
+        backup_ret_data = [{'name': 'name1', 'id': '12345', 'expiration_time': '2020-05-22T15:51:56Z'},
+                           {'name': 'name2', 'id': '67890', 'expiration_time': '2020-05-22T15:51:56Z'}]
+        backup_list = [self.backups.get_by_data(entry) for entry in backup_data]
+        backup_ids = [backup.data['id'] for backup in backup_list]
+        cluster_group_data = {"id": "12345", 'name': 'cluster_group1'}
+        cluster_group = self.cluster_groups.get_by_data(cluster_group_data)
+        mock_get.return_value = {backups.DATA_FIELD: backup_ret_data}
+        backup_obj = self.backups.set_retention(backup_list, 10, True, cluster_group)
+        self.assertIsInstance(backup_obj[0], backups.Backup)
+        self.assertEqual(backup_obj[0].data, backup_ret_data[0])
+        data = {'backup_id': backup_ids, 'retention': 10, 'force': True, 'cluster_group_id': "12345"}
+        mock_post.assert_called_once_with('/backups/set_retention', data, custom_headers=None)
+
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_set_retention_force_true_cluster_name(self, mock_get, mock_post):
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        backup_data = [{'name': 'name1', 'id': '12345', 'expiration_time': 'NA'},
+                       {'name': 'name2', 'id': '67890', 'expiration_time': 'NA'}]
+        backup_ret_data = [{'name': 'name1', 'id': '12345', 'expiration_time': '2020-05-22T15:51:56Z'},
+                           {'name': 'name2', 'id': '67890', 'expiration_time': '2020-05-22T15:51:56Z'}]
+        backup_list = [self.backups.get_by_data(entry) for entry in backup_data]
+        backup_ids = [backup.data['id'] for backup in backup_list]
+        resource_data = [{'id': '12345', 'name': 'cluster_group1'}]
+        mock_get.side_effect = [{cluster_groups.DATA_FIELD: resource_data}, {backups.DATA_FIELD: backup_ret_data}]
+        backup_obj = self.backups.set_retention(backup_list, 10, True, '12345')
+        self.assertIsInstance(backup_obj[0], backups.Backup)
+        self.assertEqual(backup_obj[0].data, backup_ret_data[0])
+        data = {'backup_id': backup_ids, 'retention': 10, 'force': True, 'cluster_group_id': "12345"}
+        mock_post.assert_called_once_with('/backups/set_retention', data, custom_headers=None)
+
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_set_retention_force_false_cluster_name(self, mock_get, mock_post):
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        backup_data = [{'name': 'name1', 'id': '12345', 'expiration_time': 'NA'},
+                       {'name': 'name2', 'id': '67890', 'expiration_time': 'NA'}]
+        backup_ret_data = [{'name': 'name1', 'id': '12345', 'expiration_time': '2020-05-22T15:51:56Z'},
+                           {'name': 'name2', 'id': '67890', 'expiration_time': '2020-05-22T15:51:56Z'}]
+        backup_list = [self.backups.get_by_data(entry) for entry in backup_data]
+        backup_ids = [backup.data['id'] for backup in backup_list]
+        resource_data = [{'id': '12345', 'name': 'cluster_group1'}]
+        mock_get.side_effect = [{cluster_groups.DATA_FIELD: resource_data}, {backups.DATA_FIELD: backup_ret_data}]
+        backup_obj = self.backups.set_retention(backup_list, 10, False, '12345')
+        self.assertIsInstance(backup_obj[0], backups.Backup)
+        self.assertEqual(backup_obj[0].data, backup_ret_data[0])
+        data = {'backup_id': backup_ids, 'retention': 10, 'force': False, 'cluster_group_id': "12345"}
+        mock_post.assert_called_once_with('/backups/set_retention', data, custom_headers=None)
+
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_set_retention_force_true_cluster_none(self, mock_get, mock_post):
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        backup_data = [{'name': 'name1', 'id': '12345', 'expiration_time': 'NA'},
+                       {'name': 'name2', 'id': '67890', 'expiration_time': 'NA'}]
+        backup_ret_data = [{'name': 'name1', 'id': '12345', 'expiration_time': '2020-05-22T15:51:56Z'},
+                           {'name': 'name2', 'id': '67890', 'expiration_time': '2020-05-22T15:51:56Z'}]
+        backup_list = [self.backups.get_by_data(entry) for entry in backup_data]
+        backup_ids = [backup.data['id'] for backup in backup_list]
+        mock_get.return_value = {backups.DATA_FIELD: backup_ret_data}
+        backup_obj = self.backups.set_retention(backup_list, 10, True)
+        self.assertIsInstance(backup_obj[0], backups.Backup)
+        self.assertEqual(backup_obj[0].data, backup_ret_data[0])
+        data = {'backup_id': backup_ids, 'retention': 10, 'force': True}
+        mock_post.assert_called_once_with('/backups/set_retention', data, custom_headers=None)
+
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_set_retention_force_false_cluster_none(self, mock_get, mock_post):
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        backup_data = [{'name': 'name1', 'id': '12345', 'expiration_time': 'NA'},
+                       {'name': 'name2', 'id': '67890', 'expiration_time': 'NA'}]
+        backup_ret_data = [{'name': 'name1', 'id': '12345', 'expiration_time': '2020-05-22T15:51:56Z'},
+                           {'name': 'name2', 'id': '67890', 'expiration_time': '2020-05-22T15:51:56Z'}]
+        backup_list = [self.backups.get_by_data(entry) for entry in backup_data]
+        backup_ids = [backup.data['id'] for backup in backup_list]
+        mock_get.return_value = {backups.DATA_FIELD: backup_ret_data}
+        backup_obj = self.backups.set_retention(backup_list, 10)
+        self.assertIsInstance(backup_obj[0], backups.Backup)
+        self.assertEqual(backup_obj[0].data, backup_ret_data[0])
+        data = {'backup_id': backup_ids, 'retention': 10, 'force': False}
+        mock_post.assert_called_once_with('/backups/set_retention', data, custom_headers=None)
 
 
 if __name__ == '__main__':

--- a/tests/unit/resources/test_omnistack_clusters.py
+++ b/tests/unit/resources/test_omnistack_clusters.py
@@ -112,6 +112,18 @@ class OmnistackClustersTest(unittest.TestCase):
         mock_get.assert_has_calls([call('/omnistack_clusters/12345/connected_clusters'),
                                   call('/omnistack_clusters?case=sensitive&id=12345&limit=500&offset=0&order=descending&sort=name')])
 
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_set_time_zone(self, mock_get, mock_post):
+        resource_data = {'id': '12345', 'name': 'name1', 'time_zone': 'Zulu'}
+        mock_get.return_value = {'omnistack_cluster': {'id': '12345', 'name': 'name1', 'time_zone': 'Africa/Accra'}}
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        cluster = self.clusters.get_by_data(resource_data)
+        cluster_obj = cluster.set_time_zone("Africa/Accra")
+        self.assertEqual(cluster_obj.data['time_zone'], "Africa/Accra")
+        data = {'time_zone': 'Africa/Accra'}
+        mock_post.assert_called_once_with('/omnistack_clusters/12345/set_time_zone', data, custom_headers=None)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Description
Add support for set retention on simplivity backups

### Issues Resolved
None

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass(`$ tox`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [ ] New endpoints supported are updated in the endpoints-support.md file.
- [ ] Changes are documented in the CHANGELOG.
