### PR TITLE
Added support for set retention backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
     - endpoint support for /backups/delete <POST>
+    - endpoint support for /backups/set_retention <POST>
     - endpoint support for /backups/{bkpId} <DELETE>
     - endpoint support for /backups/{bkpId}/lock <POST>
     - endpoint support for /backups/{bkpId}/copy <POST>

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -14,6 +14,14 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/backups/{bkpId}/lock</sub>                                  |POST    |
 |<sub>/backups/{bkpId}/rename</sub>                                |POST    |
 |<sub>/backups/{bkpId}/restore</sub>                               |POST    |
+|<sub>/backups	</sub>                                                                    |GET       |
+|<sub>/backups/delete  </sub>                                                             |POST      |
+|<sub>/backups/set_retention</sub>                                                        |POST      |
+|<sub>/backups/{bkpId}  </sub>                                                            |DELETE    |
+|<sub>/backups/{bkpId}/copy</sub>                                                            |POST    |
+|<sub>/backups/{bkpId}/lock</sub>                                                            |POST    |
+|<sub>/backups/{bkpId}/rename</sub>                                                       |POST      |
+|<sub>/backups/{bkpId}/restore  </sub>                                                    |POST      |
 |     **Cluster Groups**
 |<sub>/cluster_groups</sub>                                        |GET     |
 |<sub>/cluster_groups/{clusterGroupId}/rename</sub>                |POST    |

--- a/examples/backups.py
+++ b/examples/backups.py
@@ -136,3 +136,21 @@ print(f"{pp.pformat(copy_backup.data)} \n")
 
 copy_backup.delete()
 backup.delete()
+
+print("\n\nset retention")
+vm = machines.get_by_name(test_vm_name)
+backup1 = vm.create_backup("backup_test_from_sdk_set_retention1_" + str(time.time()))
+print(f"{backup1}")
+print(f"{pp.pformat(backup1.data)} \n")
+backup2 = vm.create_backup("backup_test_from_sdk_set_retention2_" + str(time.time()))
+print(f"{backup2}")
+print(f"{pp.pformat(backup2.data)} \n")
+
+backup_list = [backup1, backup2]
+backup_obj = backups.set_retention(backup_list, 10)
+
+for backup in backup_obj:
+    print(f"{backup}")
+    print(f"{pp.pformat(backup.data)} \n")
+
+backups.delete_multiple_backups(backup_list)

--- a/simplivity/resources/backups.py
+++ b/simplivity/resources/backups.py
@@ -18,6 +18,7 @@ from simplivity.resources.resource import ResourceBase
 from simplivity.resources import datastores
 from simplivity.resources import virtual_machines
 from simplivity.resources import omnistack_clusters
+from simplivity.resources import cluster_groups
 
 URL = '/backups'
 DATA_FIELD = 'backups'
@@ -140,6 +141,40 @@ class Backups(ResourceBase):
         data = {"backup_id": backup_ids}
 
         self._client.do_post(method_url, data, timeout, None)
+
+    def set_retention(self, backups, retention, force=False, cluster_group=None, timeout=-1):
+        """Sets the retention time for the specified list of backups.
+
+        Args:
+          backups: The list of backup objects that you want to set the retention time for.
+          retention: The number of minutes to keep backups.
+          force: An indicator to force a retention time modification even if this action results in deleting backups.
+            Valid Values:
+              True: Sets the new retention time for the specified list of backups. This action may delete of one or more
+                    backups.
+              False: Does not make the requested retention time modification if this results in deleting one or more
+                     backups. This operation returns a list of backups that the requested modification deletes. If the
+                     requested modification does not delete the backups, the retention time modification occurs.
+          cluster_group: Object/name of the cluster group.
+          timeout: Time out for the request in seconds.
+
+        Returns:
+          list: List of backup objects.
+        """
+        method_url = "{}/set_retention".format(URL)
+        backup_ids = [backup.data["id"] for backup in backups]
+        data = {"backup_id": backup_ids, "retention": retention, "force": force}
+
+        if cluster_group:
+            if not isinstance(cluster_group, cluster_groups.ClusterGroup):
+                # if passed by cluster_group name
+                cluster_group = cluster_groups.ClusterGroups(self._connection).get_by_name(cluster_group)
+            cluster_group_id = cluster_group.data["id"]
+            data["cluster_group_id"] = cluster_group_id
+        self._client.do_post(method_url, data, timeout)
+        comma_separated_ids = ','.join(backup_ids)
+
+        return self.get_all(filters={'id': comma_separated_ids})
 
 
 class Backup(object):

--- a/tests/unit/resources/test_backups.py
+++ b/tests/unit/resources/test_backups.py
@@ -23,6 +23,7 @@ from simplivity.resources import backups
 from simplivity.resources import datastores
 from simplivity.resources import virtual_machines
 from simplivity.resources import omnistack_clusters
+from simplivity.resources import cluster_groups
 
 
 class BackupTest(unittest.TestCase):
@@ -33,6 +34,7 @@ class BackupTest(unittest.TestCase):
         self.datastores = datastores.Datastores(self.connection)
         self.virtual_machines = virtual_machines.VirtualMachines(self.connection)
         self.clusters = omnistack_clusters.OmnistackClusters(self.connection)
+        self.cluster_groups = cluster_groups.ClusterGroups(self.connection)
 
     @mock.patch.object(Connection, "get")
     def test_get_all_returns_resource_obj(self, mock_get):
@@ -245,6 +247,114 @@ class BackupTest(unittest.TestCase):
         mock_post.assert_called_once_with('/backups/12345/copy',
                                           {'external_store_name': 'storeonce_catalyst_ds'},
                                           custom_headers=None)
+
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_set_retention_force_false_cluster_obj(self, mock_get, mock_post):
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        backup_data = [{'name': 'name1', 'id': '12345', 'expiration_time': 'NA'},
+                       {'name': 'name2', 'id': '67890', 'expiration_time': 'NA'}]
+        backup_ret_data = [{'name': 'name1', 'id': '12345', 'expiration_time': '2020-05-22T15:51:56Z'},
+                           {'name': 'name2', 'id': '67890', 'expiration_time': '2020-05-22T15:51:56Z'}]
+        backup_list = [self.backups.get_by_data(entry) for entry in backup_data]
+        backup_ids = [backup.data['id'] for backup in backup_list]
+        cluster_group_data = {"id": "12345", 'name': 'cluster_group1'}
+        cluster_group = self.cluster_groups.get_by_data(cluster_group_data)
+        mock_get.return_value = {backups.DATA_FIELD: backup_ret_data}
+        backup_obj = self.backups.set_retention(backup_list, 10, False, cluster_group)
+        self.assertIsInstance(backup_obj[0], backups.Backup)
+        self.assertEqual(backup_obj[0].data, backup_ret_data[0])
+        data = {'backup_id': backup_ids, 'retention': 10, 'force': False, 'cluster_group_id': "12345"}
+        mock_post.assert_called_once_with('/backups/set_retention', data, custom_headers=None)
+
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_set_retention_force_true_cluster_obj(self, mock_get, mock_post):
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        backup_data = [{'name': 'name1', 'id': '12345', 'expiration_time': 'NA'},
+                       {'name': 'name2', 'id': '67890', 'expiration_time': 'NA'}]
+        backup_ret_data = [{'name': 'name1', 'id': '12345', 'expiration_time': '2020-05-22T15:51:56Z'},
+                           {'name': 'name2', 'id': '67890', 'expiration_time': '2020-05-22T15:51:56Z'}]
+        backup_list = [self.backups.get_by_data(entry) for entry in backup_data]
+        backup_ids = [backup.data['id'] for backup in backup_list]
+        cluster_group_data = {"id": "12345", 'name': 'cluster_group1'}
+        cluster_group = self.cluster_groups.get_by_data(cluster_group_data)
+        mock_get.return_value = {backups.DATA_FIELD: backup_ret_data}
+        backup_obj = self.backups.set_retention(backup_list, 10, True, cluster_group)
+        self.assertIsInstance(backup_obj[0], backups.Backup)
+        self.assertEqual(backup_obj[0].data, backup_ret_data[0])
+        data = {'backup_id': backup_ids, 'retention': 10, 'force': True, 'cluster_group_id': "12345"}
+        mock_post.assert_called_once_with('/backups/set_retention', data, custom_headers=None)
+
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_set_retention_force_true_cluster_name(self, mock_get, mock_post):
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        backup_data = [{'name': 'name1', 'id': '12345', 'expiration_time': 'NA'},
+                       {'name': 'name2', 'id': '67890', 'expiration_time': 'NA'}]
+        backup_ret_data = [{'name': 'name1', 'id': '12345', 'expiration_time': '2020-05-22T15:51:56Z'},
+                           {'name': 'name2', 'id': '67890', 'expiration_time': '2020-05-22T15:51:56Z'}]
+        backup_list = [self.backups.get_by_data(entry) for entry in backup_data]
+        backup_ids = [backup.data['id'] for backup in backup_list]
+        resource_data = [{'id': '12345', 'name': 'cluster_group1'}]
+        mock_get.side_effect = [{cluster_groups.DATA_FIELD: resource_data}, {backups.DATA_FIELD: backup_ret_data}]
+        backup_obj = self.backups.set_retention(backup_list, 10, True, '12345')
+        self.assertIsInstance(backup_obj[0], backups.Backup)
+        self.assertEqual(backup_obj[0].data, backup_ret_data[0])
+        data = {'backup_id': backup_ids, 'retention': 10, 'force': True, 'cluster_group_id': "12345"}
+        mock_post.assert_called_once_with('/backups/set_retention', data, custom_headers=None)
+
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_set_retention_force_false_cluster_name(self, mock_get, mock_post):
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        backup_data = [{'name': 'name1', 'id': '12345', 'expiration_time': 'NA'},
+                       {'name': 'name2', 'id': '67890', 'expiration_time': 'NA'}]
+        backup_ret_data = [{'name': 'name1', 'id': '12345', 'expiration_time': '2020-05-22T15:51:56Z'},
+                           {'name': 'name2', 'id': '67890', 'expiration_time': '2020-05-22T15:51:56Z'}]
+        backup_list = [self.backups.get_by_data(entry) for entry in backup_data]
+        backup_ids = [backup.data['id'] for backup in backup_list]
+        resource_data = [{'id': '12345', 'name': 'cluster_group1'}]
+        mock_get.side_effect = [{cluster_groups.DATA_FIELD: resource_data}, {backups.DATA_FIELD: backup_ret_data}]
+        backup_obj = self.backups.set_retention(backup_list, 10, False, '12345')
+        self.assertIsInstance(backup_obj[0], backups.Backup)
+        self.assertEqual(backup_obj[0].data, backup_ret_data[0])
+        data = {'backup_id': backup_ids, 'retention': 10, 'force': False, 'cluster_group_id': "12345"}
+        mock_post.assert_called_once_with('/backups/set_retention', data, custom_headers=None)
+
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_set_retention_force_true_cluster_none(self, mock_get, mock_post):
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        backup_data = [{'name': 'name1', 'id': '12345', 'expiration_time': 'NA'},
+                       {'name': 'name2', 'id': '67890', 'expiration_time': 'NA'}]
+        backup_ret_data = [{'name': 'name1', 'id': '12345', 'expiration_time': '2020-05-22T15:51:56Z'},
+                           {'name': 'name2', 'id': '67890', 'expiration_time': '2020-05-22T15:51:56Z'}]
+        backup_list = [self.backups.get_by_data(entry) for entry in backup_data]
+        backup_ids = [backup.data['id'] for backup in backup_list]
+        mock_get.return_value = {backups.DATA_FIELD: backup_ret_data}
+        backup_obj = self.backups.set_retention(backup_list, 10, True)
+        self.assertIsInstance(backup_obj[0], backups.Backup)
+        self.assertEqual(backup_obj[0].data, backup_ret_data[0])
+        data = {'backup_id': backup_ids, 'retention': 10, 'force': True}
+        mock_post.assert_called_once_with('/backups/set_retention', data, custom_headers=None)
+
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_set_retention_force_false_cluster_none(self, mock_get, mock_post):
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        backup_data = [{'name': 'name1', 'id': '12345', 'expiration_time': 'NA'},
+                       {'name': 'name2', 'id': '67890', 'expiration_time': 'NA'}]
+        backup_ret_data = [{'name': 'name1', 'id': '12345', 'expiration_time': '2020-05-22T15:51:56Z'},
+                           {'name': 'name2', 'id': '67890', 'expiration_time': '2020-05-22T15:51:56Z'}]
+        backup_list = [self.backups.get_by_data(entry) for entry in backup_data]
+        backup_ids = [backup.data['id'] for backup in backup_list]
+        mock_get.return_value = {backups.DATA_FIELD: backup_ret_data}
+        backup_obj = self.backups.set_retention(backup_list, 10)
+        self.assertIsInstance(backup_obj[0], backups.Backup)
+        self.assertEqual(backup_obj[0].data, backup_ret_data[0])
+        data = {'backup_id': backup_ids, 'retention': 10, 'force': False}
+        mock_post.assert_called_once_with('/backups/set_retention', data, custom_headers=None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Description
Added support for set retention backups

### Issues Resolved
None

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
