### PR TITLE
Defect fix for the virtual machine power off

### DIFF
--- a/examples/virtual_machines.py
+++ b/examples/virtual_machines.py
@@ -145,7 +145,7 @@ newvm = newvm.move(vm_2_name, datastore_1_name)
 print(f"{newvm}")
 print(f"{pp.pformat(newvm.data)} \n")
 
-print("\ncreate_backup")
+print("\n\ncreate_backup")
 cluster = omnistack_clusters.get_by_name(omnistack_cluster_name)
 print("\nCluster data")
 print(f"{pp.pformat(cluster.data)} \n")
@@ -153,27 +153,28 @@ print(f"{pp.pformat(cluster.data)} \n")
 vm_backup = vm2.create_backup("backup_test_from_sdk_" + str(time.time()), cluster)
 print(f"{pp.pformat(vm_backup.data)} \n")
 
-print("Get backups of a single vm")
+print("\n\nGet backups of a single vm")
 backups = vm2.get_backups()
 pp.pprint(backups)
 
-print("\nSet backup parameters of a VM")
+print("\n\nSet backup parameters of a VM")
 guest_username = "svt"
 guest_password = "svtpassword"
 set_parameters = vm1.set_backup_parameters(guest_username, guest_password)
 print(f"{pp.pformat(set_parameters.data)} \n")
 
-print("\nSet policy")
+print("\n\nSet policy")
 vm1 = machines.get_by_name(vm_1_name)
 set_policy = vm1.set_policy(policy_name)
 print(f"{pp.pformat(set_policy.data)} \n")
 
-print("\nPower off")
+print("\n\npower off")
 vm1 = machines.get_by_name(vm_1_name)
 vm_powered_off = vm1.power_off()
-print(f"{pp.pformat(vm_powered_off.data)} \n")
+if (vm_powered_off):
+    print("\nVM Successfully powered off.")
 
-print("\nPower on")
+print("\n\npower on")
 vm1 = machines.get_by_name(vm_1_name)
 vm_powered_on = vm1.power_on()
 if (vm_powered_on):

--- a/simplivity/resources/virtual_machines.py
+++ b/simplivity/resources/virtual_machines.py
@@ -339,7 +339,10 @@ class VirtualMachine(object):
         self._client.do_post(method_url, None, timeout, custom_headers)
         self.__refresh()
 
-        return self
+        if self.data["hypervisor_virtual_machine_power_state"] == "OFF":
+            return True
+        else:
+            return False
 
     def power_on(self, timeout=-1):
         """Power on virtual machine.

--- a/tests/unit/resources/test_virtual_machines.py
+++ b/tests/unit/resources/test_virtual_machines.py
@@ -275,14 +275,32 @@ class VirtualMachinesTest(unittest.TestCase):
 
     @mock.patch.object(Connection, "post")
     @mock.patch.object(Connection, "get")
-    def test_power_off(self, mock_get, mock_post):
+    def test_power_off_success(self, mock_get, mock_post):
+        resource_data = {'name': 'name1', 'id': '12345', 'hypervisor_virtual_machine_power_state': 'OFF'}
         mock_post.return_value = None, [{'object_id': '12345'}]
-        mock_get.return_value = {'virtual_machine': {'id': '12345'}}
+        mock_get.return_value = {'virtual_machine': resource_data}
 
-        vm1_data = {'name': 'name1', 'id': '12345'}
+        vm1_data = {'name': 'name1', 'id': '12345', 'hypervisor_virtual_machine_power_state': 'ON'}
         vm = self.machines.get_by_data(vm1_data)
+        boolreturn = vm.power_off()
 
-        vm.power_off()
+        self.assertEqual(vm.data, resource_data)
+        self.assertIsInstance(boolreturn, bool)
+        mock_post.assert_called_once_with('/virtual_machines/12345/power_off', None, custom_headers={'Content-type': 'application/vnd.simplivity.v1.11+json'})
+
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_power_off_failure(self, mock_get, mock_post):
+        resource_data = {'name': 'name1', 'id': '12345', 'hypervisor_virtual_machine_power_state': 'ON'}
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        mock_get.return_value = {'virtual_machine': resource_data}
+
+        vm1_data = {'name': 'name1', 'id': '12345', 'hypervisor_virtual_machine_power_state': 'ON'}
+        vm = self.machines.get_by_data(vm1_data)
+        boolreturn = vm.power_off()
+
+        self.assertEqual(vm.data, resource_data)
+        self.assertIsInstance(boolreturn, bool)
         mock_post.assert_called_once_with('/virtual_machines/12345/power_off', None, custom_headers={'Content-type': 'application/vnd.simplivity.v1.11+json'})
 
     @mock.patch.object(Connection, "post")


### PR DESCRIPTION
Signed-off-by: KalpanaBhardwaj <bhardwaj@hpe.com>

### Description
To return true or false for VM "power_off" method to be consistent with "power_on" method.

### Issues Resolved
fixing defect #49 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
