### PR TITLE
Add support to fetch standard hosts for the simplivity datastores 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /datastore/{datastoreId} <DELETE>
     - endpoint support for /datastore/{datastoreId}/resize <POST>
     - endpoint support for /datastore/{datastoreId}/set_policy <POST>
+    - endpoint support for /datastore/{datastoreId}/standard_hosts <GET>
     - endpoint support for /hosts/{hostId}/cancel_virtual_controller_shutdown <POST>
     - endpoint support for /hosts/{hostId}/remove_from_federation <POST>    
     - endpoint support for /hosts/{hostId}/shutdown_virtual_controller <POST>

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -21,6 +21,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/datastores/{datastoreId}  </sub>                                                   |DELETE    |
 |<sub>/datastores/{datastoreId}/resize  </sub>                                            |POST      |
 |<sub>/datastores/{datastoreId}/set_policy  </sub>                                        |POST      |
+|<sub>/datastores/{datastoreId}/standard_hosts</sub>                                     |GET       |
 |     **Hosts**
 |<sub>/hosts	</sub>                                                                    |GET       |
 |<sub>/hosts/{hostId}/cancel_virtual_controller_shutdown </sub>                 	  |POST      |

--- a/examples/datastores.py
+++ b/examples/datastores.py
@@ -105,6 +105,11 @@ datastore_object.set_policy(policy_object)
 print(f"{datastore_object}")
 print(f"{pp.pformat(datastore_object.data)} \n")
 
+# Get standard hosts on the datastore
+print("\n\nget standard hosts on the datastore")
+hosts = datastore_object.standard_hosts()
+print(f"{pp.pformat(hosts)} \n")
+
 print("\n\ndatastore delete")
 all_datastores = datastores.get_all()
 count = len(all_datastores)

--- a/simplivity/resources/datastores.py
+++ b/simplivity/resources/datastores.py
@@ -203,3 +203,13 @@ class Datastore(object):
         self.__refresh()
 
         return self
+
+    def standard_hosts(self):
+        """Gets the standard hosts that can share a datastore.
+
+        Returns:
+            list: List of standard hosts objects.
+
+        """
+        resource_uri = "{}/{}/standard_hosts".format(URL, self.data["id"])
+        return self._client.do_get(resource_uri)

--- a/tests/unit/resources/test_datastores.py
+++ b/tests/unit/resources/test_datastores.py
@@ -208,6 +208,18 @@ class DatastoresTest(unittest.TestCase):
         mock_post.assert_called_once_with('/datastores/12345/set_policy', {'policy_id': '4567'},
                                           custom_headers=None)
 
+    @mock.patch.object(Connection, "get")
+    def test_standard_hosts(self, mock_get):
+        resource_data = {'standard_hosts': [{'hypervisor_object_id': '1234', 'ip_address': '10.1.2.5',
+                         'name': 'host', 'shared': False, 'virtual_machine_count': 0}]}
+        mock_get.return_value = resource_data
+
+        datastore_data = {'id': '12345'}
+        datastore = self.datastores.get_by_data(datastore_data)
+
+        standard_hosts = datastore.standard_hosts()
+        self.assertEqual(standard_hosts, resource_data)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Mitali Gawade <mitali.gawade@hpe.com>

### Description
Add support to fetch standard hosts for the simplivity datastores 

### Issues Resolved
None

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
