### PR TITLE
Add support for copy the simplivity backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /backups/delete <POST>
     - endpoint support for /backups/{bkpId} <DELETE>
     - endpoint support for /backups/{bkpId}/lock <POST>
+    - endpoint support for /backups/{bkpId}/copy <POST>
     - endpoint support for /backups/{bkpId}/rename <POST>
     - endpoint support for /backups/{bkpId}/restore <POST>
     - endpoint support for /cluster_groups <GET>

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -10,6 +10,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/backups	</sub>                                                                    |GET       |
 |<sub>/backups/delete  </sub>                                                             |POST      |
 |<sub>/backups/{bkpId}  </sub>                                                            |DELETE    |
+|<sub>/backups/{bkpId}/copy</sub>                                                            |POST    |
 |<sub>/backups/{bkpId}/lock</sub>                                                            |POST    |
 |<sub>/backups/{bkpId}/rename</sub>                                                       |POST      |
 |<sub>/backups/{bkpId}/restore  </sub>                                                    |POST      |

--- a/examples/backups.py
+++ b/examples/backups.py
@@ -36,6 +36,8 @@ datastores = ovc.datastores
 # variable declaration
 test_vm_name = "test_MySql-VM_restore"
 remote_datastore = "remoteDS"
+cluster1_name = "CC_Virt_0001"
+cluster2_name = "CC_Virt_0000"
 
 print("\n\nget_all with default params")
 all_backups = backups.get_all()
@@ -121,5 +123,16 @@ backup.rename(f"renamed_{backup.data['name']}")
 print(f"{backup}")
 print(f"{pp.pformat(backup.data)} \n")
 
+backup.delete()
 
+print("\n\ncopy backup")
+backup = vm.create_backup("backup_test_from_sdk_" + str(time.time()), cluster1_name)
+print(f"{backup}")
+print(f"{pp.pformat(backup.data)} \n")
+
+copy_backup = backup.copy(cluster2_name)
+print(f"{copy_backup}")
+print(f"{pp.pformat(copy_backup.data)} \n")
+
+copy_backup.delete()
 backup.delete()


### PR DESCRIPTION
Signed-off-by: Hemant Chaudhari <hchaudhari@hpe.com>

### Description
Add support for copy the simplivity backup

### Issues Resolved
None

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
