### PR TITLE
Add support to generate impact report based on proposed creation of rules for the policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /policies/resume <POST>
     - endpoint support for /policies/suspend <POST>
     - endpoint support for /policies/{policyId} <DELETE>
+    - endpoint support for /policies/{policyId}/impact_report/create_rules <POST>
     - endpoint support for /policies/{policyId}/rename <POST>
     - endpoint support for /policies/{policyId}/rules <POST>
     - endpoint support for /policies/{policyId}/rules/{ruleId} <GET>

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -42,6 +42,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/policies/resume </sub>                                      |POST    |
 |<sub>/policies/suspend</sub>                                      |POST    |
 |<sub>/policies/{policyId}</sub>                                   |DELETE  |
+|<sub>/policies/{policyId}/impact_report/create_rules</sub>        |POST    |
 |<sub>/policies/{policyId}/rename</sub>                            |POST    |
 |<sub>/policies/{policyId}/rules</sub>                             |POST    |
 |<sub>/policies/{policyId}/rules/{ruleId}</sub>                    |GET     |

--- a/examples/policies.py
+++ b/examples/policies.py
@@ -182,5 +182,17 @@ federation options works only with setup NOT having MVA, please use below code f
 policies.resume("federation")
 """
 
+print("\n\nbackup impact report for policy single rule")
+impact_report = policy.impact_create_rules(single_rule)
+print(f"{pp.pformat(impact_report)} \n")
+
+print("\n\nbackup impact report for policy single rule and replace")
+impact_report = policy.impact_create_rules(single_rule, True)
+print(f"{pp.pformat(impact_report)} \n")
+
+print("\n\nbackup impact report for policy multiple rules")
+impact_report = policy.impact_create_rules(multiple_rules)
+print(f"{pp.pformat(impact_report)} \n")
+
 print("\n\ndelete policy")
 policy.delete()

--- a/simplivity/resources/policies.py
+++ b/simplivity/resources/policies.py
@@ -301,3 +301,48 @@ class Policy(object):
         self.__refresh()
 
         return self
+
+    def impact_create_rules(self, rules, replace_all_rules=False, timeout=-1):
+        """Generate a backup impact reported based on proposed creation of rules for the policy
+
+        Args:
+            rules: Array of rules.(below are the parameter that can be passed in the array)
+                [Mandatory Parameters]
+                frequency: The number of minutes between backups
+                retention: The number of minutes to keep backups
+                [Optional Parameters]
+                application_consistent: Set false for crash-consistent backups
+                                        Set true for application-consistent backups (for example, VSS or snapshot backups)
+                                        Default: false
+                consistency_type: Set to DEFAULT for a snapshot backup
+                                  Set to VSS for a Microsoft Volume Shadow Copy Service backup
+                                  Set to NONE for crash-consistent backups
+                                  Default: NONE
+                destination_id: The unique identifier (UID) of the omnistack_cluster to store the backup
+                                Default: local omnistack_cluster
+                days: The days of the week (for example, Mon,Fri), or month (for example, 1,15) to take backups or
+                      "last" to specify the last day of each month
+                      Default: All (that is, every day)
+                start_time: The time to start the backups, for example, 14:30
+                            This time is local to the time zone of the Hypervisor Management System (HMS)
+                            Default: 00:00
+                end_time: The time to stop backing up, for example, 14:30
+                          This time is local to the time zone of the Hypervisor Management System (HMS)
+                          Default: 00:00
+                external_store_name: The name of the external_store
+
+            replace_all_rules: If set to True, replaces the existing rules with new rules
+                               If set to False, adds the new rules to existing set of rules
+            timeout: Time out for the request in seconds.
+
+        Returns:
+            dict : Returns the dictionary for impact report of created rules.
+        """
+        resource_uri = "{}/{}/impact_report/create_rules".format(URL, self.data["id"])
+        custom_headers = {'Content-type': 'application/vnd.simplivity.v1.14+json'}
+        if isinstance(rules, dict):
+            rules = [rules]
+
+        flags = {'replace_all_rules': replace_all_rules}
+
+        return self._client.do_post(resource_uri, rules, timeout, custom_headers, flags)

--- a/tests/unit/resources/test_policies.py
+++ b/tests/unit/resources/test_policies.py
@@ -345,6 +345,64 @@ class PoliciesTest(unittest.TestCase):
         self.assertEqual(response_policy.data, resources_data)
         mock_put.assert_called_once_with('/policies/67890/rules/12345', updated_rule, custom_headers=None)
 
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_impact_create_rules(self, mock_get, mock_post):
+        data = {"projected_retained_backups_level": 0, "daily_backup_rate": 2, "backup_rate_level": 0,
+                "projected_retained_backups": 0, "daily_backup_rate_limit": 217, "retained_backups_limit": 75}
+        resource_data = {"schedule_after_change": data, "schedule_before_change": data}
+        mock_post.return_value = None, resource_data
+        policy_data = {"name": "policy1", "id": "12345"}
+
+        mock_get.return_value = {'policy': policy_data}
+        policy_obj = self.policies.get_by_data(policy_data)
+        rules = {
+            "frequency": 1,
+            "retention": 5
+        }
+        report = policy_obj.impact_create_rules(rules)
+        self.assertEqual(report, resource_data)
+        mock_post.assert_called_once_with('/policies/12345/impact_report/create_rules?replace_all_rules=False', [rules],
+                                          custom_headers={"Content-type": "application/vnd.simplivity.v1.14+json"})
+
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_impact_create_replace_rules(self, mock_get, mock_post):
+        data = {"projected_retained_backups_level": 0, "daily_backup_rate": 2, "backup_rate_level": 0,
+                "projected_retained_backups": 0, "daily_backup_rate_limit": 217, "retained_backups_limit": 75}
+        resource_data = {"schedule_after_change": data, "schedule_before_change": data}
+        mock_post.return_value = None, resource_data
+        policy_data = {"name": "policy1", "id": "12345"}
+
+        mock_get.return_value = {'policy': policy_data}
+        policy_obj = self.policies.get_by_data(policy_data)
+        rules = {
+            "frequency": 1,
+            "retention": 5
+        }
+        report = policy_obj.impact_create_rules(rules, replace_all_rules=True)
+        self.assertEqual(report, resource_data)
+        mock_post.assert_called_once_with('/policies/12345/impact_report/create_rules?replace_all_rules=True', [rules],
+                                          custom_headers={"Content-type": "application/vnd.simplivity.v1.14+json"})
+
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_impact_create_multiple_rules(self, mock_get, mock_post):
+        data = {"projected_retained_backups_level": 0, "daily_backup_rate": 2, "backup_rate_level": 0,
+                "projected_retained_backups": 0, "daily_backup_rate_limit": 217, "retained_backups_limit": 75}
+        resource_data = {"schedule_after_change": data, "schedule_before_change": data}
+        mock_post.return_value = None, resource_data
+        policy_data = {"name": "policy1", "id": "12345"}
+
+        mock_get.return_value = {'policy': policy_data}
+        policy_obj = self.policies.get_by_data(policy_data)
+        rules = [{"frequency": 5, "retention": 1},
+                 {"frequency": 10, "retention": 2}]
+        report = policy_obj.impact_create_rules(rules)
+        self.assertEqual(report, resource_data)
+        mock_post.assert_called_once_with('/policies/12345/impact_report/create_rules?replace_all_rules=False', rules,
+                                          custom_headers={"Content-type": "application/vnd.simplivity.v1.14+json"})
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Mitali Gawade <mitali.gawade@hpe.com>

### Description
Add support to generate impact report based on proposed creation of rules for the policy
### Issues Resolved
None
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
