### PR TITLE
Add support to generate a impact report based on a policy to one or more virtual machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /policies/{policyId}/rules/{ruleId} <PUT>
     - endpoint support for /virtual_machines/{vmId}/power_off <POST>
     - endpoint support for /virtual_machines/{vmId}/power_on <POST>
+    - endpoint support for /virtual_machines/policy_impact_report/apply_policy <POST>
     - missing connection unit tests to improve code coverage
     - missing ovc client host unit tests to improve code coverage
     - pull request template to facilitate pull requests

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -54,6 +54,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/policies/{policyId}/rules/{ruleId}</sub>                    |PUT     |
 |     **Virtual Machines**
 |<sub>/virtual_machines</sub>                                      |GET     |
+|<sub>/virtual_machines/policy_impact_report/apply_policy</sub>    |POST    |
 |<sub>/virtual_machines/set_policy</sub>                           |POST    |
 |<sub>/virtual_machines/{vmId}</sub>                               |GET     |
 |<sub>/virtual_machines/{vmId}/backup</sub>                        |POST    |

--- a/examples/virtual_machines.py
+++ b/examples/virtual_machines.py
@@ -179,3 +179,10 @@ vm1 = machines.get_by_name(vm_1_name)
 vm_powered_on = vm1.power_on()
 if (vm_powered_on):
     print("\nVM Successfully powered on.")
+
+print("\n\nImpact report for multiple vms applied policy")
+vm1 = machines.get_by_name(vm_1_name)
+vm2 = machines.get_by_name(vm_2_name)
+vms = [vm1, vm2]
+report = machines.policy_impact_report(policy, vms)
+print(f"{pp.pformat(report)} \n")

--- a/simplivity/resources/virtual_machines.py
+++ b/simplivity/resources/virtual_machines.py
@@ -153,6 +153,30 @@ class VirtualMachines(ResourceBase):
 
         return self.get_all(filters={'id': comma_separated_ids})
 
+    def policy_impact_report(self, policy, vms, timeout=-1):
+        """Generate a backup impact reported based on proposed application of a policy to one or more virtual machines.
+
+        Args:
+            policy: Policy object/name
+            vms: List of vm objects
+            timeout: Time out for the request in seconds.
+
+        Returns:
+            dict: Returns the dictionary for impact report of policy applied on virtual machines.
+        """
+        method_url = "{}/policy_impact_report/apply_policy".format(URL)
+        custom_headers = {'Content-type': 'application/vnd.simplivity.v1.14+json'}
+
+        vm_ids = [vm.data["id"] for vm in vms]
+        if not isinstance(policy, policies.Policy):
+            # if passed name of the policy
+            policy = policies.Policies(self._connection).get_by_name(policy)
+
+        data = {"virtual_machine_id": vm_ids,
+                "policy_id": policy.data["id"]}
+
+        return self._client.do_post(method_url, data, timeout, custom_headers)
+
 
 class VirtualMachine(object):
     """Implements features available for a single VM."""


### PR DESCRIPTION


Signed-off-by: Mitali Gawade <mitali.gawade@hpe.com>

### Description
Add support to generate a impact report based on a policy to one or more virtual machines
### Issues Resolved
None
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
