### PR TITLE
Adding support to register the external store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /datastore/{datastoreId}/set_policy <POST>
     - endpoint support for /datastore/{datastoreId}/standard_hosts <GET>
     - endpoint support for /external_stores <GET>
+    - endpoint support for /external_stores <POST>
     - endpoint support for /hosts/{hostId}/cancel_virtual_controller_shutdown <POST>
     - endpoint support for /hosts/{hostId}/remove_from_federation <POST>    
     - endpoint support for /hosts/{hostId}/shutdown_virtual_controller <POST>

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -28,6 +28,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/datastores/{datastoreId}/standard_hosts</sub>               |GET     |
 |     **External Stores**
 |<sub>/external_stores</sub>                                       |GET     |
+|<sub>/external_stores</sub>                                       |POST    |
 |     **Hosts**
 |<sub>/hosts</sub>                                                 |GET     |
 |<sub>/hosts/{hostId}/cancel_virtual_controller_shutdown</sub>     |POST    |

--- a/examples/external_stores.py
+++ b/examples/external_stores.py
@@ -26,9 +26,20 @@ config = {
     }
 }
 
+# variable declaration
+management_ip = '<storeonce_management_ip>'
+management_port = '<storeonce_management_port>'
+external_store_type = '<external_store_type>'
+external_store_name = '<storeonce_storename>'
+username = '<storeonce_username>'
+password = '<storeonce_password>'
+storage_port = '<storage_port>'
+cluster_name = '<cluster_name>'
+
 pp = pprint.PrettyPrinter(indent=4)
 ovc = OVC(config)
 external_stores = ovc.external_stores
+clusters = ovc.omnistack_clusters
 
 print("\n\nget_all with default params")
 all_external_stores = external_stores.get_all()
@@ -37,11 +48,11 @@ for external_store in all_external_stores:
     print(f"{external_store}")
     print(f"{pp.pformat(external_store.data)} \n")
 
-print("\n\nTotal number of backups {}".format(count))
-backup_object = all_external_stores[0]
+print("\n\nTotal number of external stores {}".format(count))
+external_store_object = all_external_stores[0]
 
 print("\n\nget_all with filters")
-all_external_stores = external_stores.get_all(filters={'name': backup_object.data["name"]})
+all_external_stores = external_stores.get_all(filters={'name': external_store_object.data["name"]})
 for external_store in all_external_stores:
     print(f"{external_store}")
     print(f"{pp.pformat(external_store.data)} \n")
@@ -60,3 +71,11 @@ while not end:
         pagination.next_page()
     except HPESimpliVityException:
         end = True
+
+print("\n\nregister external store")
+cluster_obj = clusters.get_by_name(cluster_name)
+external_store_obj = external_stores.register_external_store(management_ip, external_store_name,
+                                                             cluster_obj, username, password)
+
+print(f"{external_store_obj}")
+print(f"{pp.pformat(external_store_obj.data)} \n")

--- a/simplivity/resources/external_stores.py
+++ b/simplivity/resources/external_stores.py
@@ -15,6 +15,7 @@
 ##
 
 from simplivity.resources.resource import ResourceBase
+from simplivity.resources import omnistack_clusters
 
 URL = '/external_stores'
 DATA_FIELD = 'external_stores'
@@ -76,6 +77,38 @@ class ExternalStores(ResourceBase):
         """
 
         return ExternalStore(self._connection, self._client, data)
+
+    def register_external_store(self, management_ip, name, cluster, username, password, management_port=9387,
+                                storage_port=9388, external_store_type='StoreOnceOnPrem', timeout=-1):
+        """ Register the external store.
+        Args:
+            management_ip: The IP address of the external store
+            name: The name of the external_store
+            cluster: Destination OmnistackCluster object/name.
+            username: The client name of the external store
+            password: The client password of the external store
+            management_port: The management IP port of the external store. Default: 9387
+            storage_port: The storage IP port of the external store. Default: 9388
+            external_store_type: The type of external store. Default: StoreOnceOnPrem
+            timeout: Time out for the request in seconds.
+
+        Returns:
+            object: External store object.
+        """
+
+        data = {'management_ip': management_ip, 'management_port': management_port, 'name': name,
+                'username': username, 'password': password, 'storage_port': storage_port,
+                'type': external_store_type}
+
+        if not isinstance(cluster, omnistack_clusters.OmnistackCluster):
+            # if passed name of the cluster
+            clusters_obj = omnistack_clusters.OmnistackClusters(self._connection)
+            cluster = clusters_obj.get_by_name(cluster)
+
+        data['omnistack_cluster_id'] = cluster.data['id']
+        self._client.do_post(URL, data, timeout)
+
+        return self.get_by_name(name)
 
 
 class ExternalStore(object):


### PR DESCRIPTION
Signed-off-by: Hemant Chaudhari <hchaudhari@hpe.com>

### Description
Adding support to register the external store

### Issues Resolved
None

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
