### PR TITLE
Add support to validate the credentials for the virtual machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /virtual_machines/{vmId}/power_off <POST>
     - endpoint support for /virtual_machines/{vmId}/power_on <POST>
     - endpoint support for /virtual_machines/policy_impact_report/apply_policy <POST>
+    - endpoint support for /virtual_machines/{vmId}/validate_backup_credentials <POST>
     - missing connection unit tests to improve code coverage
     - missing ovc client host unit tests to improve code coverage
     - pull request template to facilitate pull requests

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -69,3 +69,4 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/virtual_machines/{vmId}/power_off</sub>                     |POST    |
 |<sub>/virtual_machines/{vmId}/power_on</sub>                      |POST    |
 |<sub>/virtual_machines/{vmId}/set_policy</sub>                    |POST    |
+|<sub>/virtual_machines/{vmId}/validate_backup_credentials</sub>   |POST    |

--- a/examples/virtual_machines.py
+++ b/examples/virtual_machines.py
@@ -168,6 +168,10 @@ vm1 = machines.get_by_name(vm_1_name)
 set_policy = vm1.set_policy(policy_name)
 print(f"{pp.pformat(set_policy.data)} \n")
 
+print("\n\nvalidating the credentials for the virtual machine")
+status = vm1.validate_backup_credentials(guest_username, guest_password)
+print(f"{pp.pformat(status)} \n")
+
 print("\n\npower off")
 vm1 = machines.get_by_name(vm_1_name)
 vm_powered_off = vm1.power_off()

--- a/simplivity/resources/virtual_machines.py
+++ b/simplivity/resources/virtual_machines.py
@@ -386,3 +386,22 @@ class VirtualMachine(object):
             return True
         else:
             return False
+
+    def validate_backup_credentials(self, guest_username, guest_password, timeout=-1):
+        """Validates the credentials for the virtual machine want to backup.
+
+        Args:
+            guest_username: Username of the virtual machine.
+            guest_password: Password of the virtual machine.
+            timeout: Time out for the request in seconds.
+
+        Returns:
+            status: Possible values are 'VALID', 'INVALID'.
+        """
+        method_url = "{}/{}/validate_backup_credentials".format(URL, self.data["id"])
+        data = {"guest_username": guest_username,
+                "guest_password": guest_password}
+
+        status = self._client.do_post(method_url, data, timeout)
+
+        return status['credentials_validation']['status']

--- a/tests/unit/resources/test_virtual_machines.py
+++ b/tests/unit/resources/test_virtual_machines.py
@@ -386,6 +386,22 @@ class VirtualMachinesTest(unittest.TestCase):
                                           {'policy_id': '12345', 'virtual_machine_id': ['id1', 'id2']},
                                           custom_headers={'Content-type': 'application/vnd.simplivity.v1.14+json'})
 
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_validate_backup_credentials(self, mock_get, mock_post):
+        mock_post.return_value = None, {'credentials_validation': {'status': 'VALID'}}
+        mock_get.return_value = {'virtual_machine': [{'name': 'name', 'id': '12345'}]}
+
+        username = "username"
+        password = "password"
+        vm1_data = {'name': 'name1', 'id': '12345'}
+        vm = self.machines.get_by_data(vm1_data)
+        status = vm.validate_backup_credentials(username, password)
+
+        self.assertEqual(status, 'VALID')
+        mock_post.assert_called_once_with('/virtual_machines/12345/validate_backup_credentials', {'guest_username': username, 'guest_password': password},
+                                          custom_headers=None)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Mitali Gawade <mitali.gawade@hpe.com>

### Description
Add support to validate the credentials for the virtual machine
### Issues Resolved
None

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
