### PR TITLE
Fix for exception  thrown from connection.py if resp_body is None or empty from method do_http

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - resolve the virtual machine `__refresh` method
     - url encode query string to support values that contain spaces
     - resolve `do_get` method to append filters to uri
+    - resolve add check to `do_http` method for empty response body
 
 ### Removed
     - external test dependency for mock module    

--- a/simplivity/connection.py
+++ b/simplivity/connection.py
@@ -77,18 +77,20 @@ class Connection(object):
         if custom_headers:
             http_headers.update(custom_headers)
 
+        json_body = None
         try:
             connection = self.get_connection()
             connection.request(method, full_path, body, http_headers)
             resp = connection.getresponse()
             resp_body = resp.read()
             connection.close()
-            json_body = json.loads(resp_body.decode('utf-8'))
+            if resp_body:
+                json_body = json.loads(resp_body.decode('utf-8'))
         except http.client.HTTPException:
             raise exceptions.HPESimpliVityException(traceback.format_exc())
 
         # Obtain a new token, if the Simplivity Product returns an invalid token error.
-        if 'error' in json_body and json_body['error'] == 'invalid_token':
+        if json_body and 'error' in json_body and json_body['error'] == 'invalid_token':
             self.login(self._username, self._password)
             resp, json_body = self.do_http(method, path, body, custom_headers)
 

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -308,6 +308,20 @@ class ConnectionTest(unittest.TestCase):
         self.assertEqual(conn.port, 443)
         self.assertEqual(conn._context.protocol, ssl.PROTOCOL_TLSv1_2)
 
+    @patch.object(Connection, 'login')
+    @patch.object(Connection, 'get_connection')
+    def test_do_http_with_none_response(self, mock_connection, mock_login):
+        mock_none_response = self.__make_http_response(
+            status=204,
+            response_body=None
+        )
+        mock_conn = mock_connection.return_value = Mock()
+        mock_conn.getresponse.return_value = mock_none_response
+
+        resp, body = self.connection.do_http('POST', '/rest/test', 'body')
+
+        self.assertEqual(body, self.expected_response_body)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Description
Fix for exception  thrown from connection.py if resp_body is None or empty from method do_http

### Issues Resolved
Fixes #81 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
