### PR TITLE
Add support for the unregister of the external store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /datastore/{datastoreId}/unshare <POST>
     - endpoint support for /external_stores <GET>
     - endpoint support for /external_stores <POST>
+    - endpoint support for /external_stores/unregister <POST>
     - endpoint support for /external_stores/update_credentials <POST>
     - endpoint support for /hosts/{hostId}/capacity <GET>
     - endpoint support for /hosts/{hostId}/cancel_virtual_controller_shutdown <POST>

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -33,6 +33,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |     **External Stores**
 |<sub>/external_stores</sub>                                                                 |GET     |
 |<sub>/external_stores</sub>                                                                 |POST    |
+|<sub>/external_stores/unregister</sub>                                                      |POST    |
 |<sub>/external_stores/update_credentials</sub>                                              |POST    |
 |     **Hosts**
 |<sub>/hosts</sub>                                                                           |GET     |

--- a/examples/external_stores.py
+++ b/examples/external_stores.py
@@ -83,3 +83,7 @@ print(f"{pp.pformat(external_store_obj.data)} \n")
 print("\n\nupdate external store access credential")
 # We can provide the updated credential to access the external store
 external_stores.update_credentials(external_store_name, username, password)
+
+print("\n\nunregister external store")
+cluster_obj = clusters.get_by_name(cluster_name)
+external_store_obj.unregister_external_store(cluster_obj)

--- a/simplivity/resources/external_stores.py
+++ b/simplivity/resources/external_stores.py
@@ -141,3 +141,25 @@ class ExternalStore(object):
         self.data = data
         self._connection = connection
         self._client = resource_client
+
+    def unregister_external_store(self, cluster, timeout=-1):
+        """ Removes the external store as a backup destination for the cluster.
+        Backups remain on the external store,but they can no longer be managed by HPE SimpliVity.
+        Args:
+            cluster: Destination OmnistackCluster object/name.
+            timeout: Time out for the request in seconds.
+
+        Returns:
+            None
+        """
+
+        resource_uri = "{}/unregister".format(URL)
+        data = {'name': self.data["name"]}
+        if not isinstance(cluster, omnistack_clusters.OmnistackCluster):
+            # if passed name of the cluster
+            clusters_obj = omnistack_clusters.OmnistackClusters(self._connection)
+            cluster = clusters_obj.get_by_name(cluster)
+
+        data['omnistack_cluster_id'] = cluster.data['id']
+        custom_headers = {'Content-type': 'application/vnd.simplivity.v1.15+json'}
+        self._client.do_post(resource_uri, data, timeout, custom_headers)

--- a/tests/unit/resources/test_external_stores.py
+++ b/tests/unit/resources/test_external_stores.py
@@ -121,6 +121,37 @@ class ExternalStoresTest(unittest.TestCase):
         mock_post.assert_called_once_with('/external_stores/update_credentials', data,
                                           custom_headers={'Content-type': 'application/vnd.simplivity.v1.15+json'})
 
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_unregister_external_store_cluster_name(self, mock_get, mock_post):
+        cluster_data = {'name': 'cluster1', 'id': '12345'}
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        mock_get.return_value = {clusters.DATA_FIELD: [cluster_data]}
+        resource_data = {'name': 'storeonce_cat1'}
+
+        external_store_obj = self.external_stores.get_by_data(resource_data)
+        external_store_obj.unregister_external_store('cluster1')
+
+        data = {'name': 'storeonce_cat1', 'omnistack_cluster_id': '12345'}
+        mock_post.assert_called_once_with('/external_stores/unregister', data,
+                                          custom_headers={'Content-type': 'application/vnd.simplivity.v1.15+json'})
+
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_unregister_external_store_cluster_obj(self, mock_get, mock_post):
+        cluster_data = {'name': 'cluster1', 'id': '12345'}
+        cluster_obj = self.clusters.get_by_data(cluster_data)
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        mock_get.return_value = {clusters.DATA_FIELD: [cluster_data]}
+        resource_data = {'name': 'storeonce_cat1'}
+
+        external_store_obj = self.external_stores.get_by_data(resource_data)
+        external_store_obj.unregister_external_store(cluster_obj)
+
+        data = {'name': 'storeonce_cat1', 'omnistack_cluster_id': '12345'}
+        mock_post.assert_called_once_with('/external_stores/unregister', data,
+                                          custom_headers={'Content-type': 'application/vnd.simplivity.v1.15+json'})
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Hemant Chaudhari <hchaudhari@hpe.com>

### Description
Add support for the unregister of the external store

### Issues Resolved
None

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
