### PR TITLE
Add support to get virtual machine metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /policies/{policyId}/rules/{ruleId} <PUT>
     - endpoint support for /policies/{policyId}/rules/{ruleId}/impact_report/delete_rule <POST>
     - endpoint support for /security/certificates <GET>
+    - endpoint support for /virtual_machines/{vmId}/metrics <GET>
     - endpoint support for /virtual_machines/{vmId}/power_off <POST>
     - endpoint support for /virtual_machines/{vmId}/power_on <POST>
     - endpoint support for /virtual_machines/policy_impact_report/apply_policy <POST>

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -71,6 +71,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/virtual_machines/{vmId}/backup_parameters</sub>                                       |POST    |
 |<sub>/virtual_machines/{vmId}/backups</sub>                                                 |GET     |
 |<sub>/virtual_machines/{vmId}/clone</sub>                                                   |POST    |
+|<sub>/virtual_machines/{vmId}/metrics</sub>                                                 |GET     |
 |<sub>/virtual_machines/{vmId}/move</sub>                                                    |POST    |
 |<sub>/virtual_machines/{vmId}/power_off</sub>                                               |POST    |
 |<sub>/virtual_machines/{vmId}/power_on</sub>                                                |POST    |

--- a/examples/virtual_machines.py
+++ b/examples/virtual_machines.py
@@ -190,3 +190,7 @@ vm2 = machines.get_by_name(vm_2_name)
 vms = [vm1, vm2]
 report = machines.policy_impact_report(policy, vms)
 print(f"{pp.pformat(report)} \n")
+
+print("\n\nget vm metrics data")
+metrics_response = vm1.get_metrics()
+print(f"{pp.pformat(metrics_response)} \n")

--- a/simplivity/resources/virtual_machines.py
+++ b/simplivity/resources/virtual_machines.py
@@ -405,3 +405,20 @@ class VirtualMachine(object):
         status = self._client.do_post(method_url, data, timeout)
 
         return status['credentials_validation']['status']
+
+    def get_metrics(self, time_offset=0, range=43200, resolution='MINUTE'):
+        """Retrieves throughput, IOPS, and latency data for the virtual machine
+
+        Args:
+            time_offset: A time offset in seconds (from now) or a datetime,
+                        expressed in ISO-8601 form, based on Coordinated Universal Time (UTC) Default: 0
+            range: A range in seconds (the duration from the specified point in time) Default: 43200
+            resolution: The resolution (SECOND, MINUTE, HOUR, or DAY) Default: MINUTE
+
+        Returns:
+            dict: Dictionary of metrics object.
+        """
+        method_url = "{}/{}/metrics".format(URL, self.data["id"])
+        filters = {'time_offset': time_offset, 'range': range, 'resolution': resolution}
+
+        return self._client.do_get(method_url, filters)

--- a/tests/unit/resources/test_virtual_machines.py
+++ b/tests/unit/resources/test_virtual_machines.py
@@ -402,6 +402,23 @@ class VirtualMachinesTest(unittest.TestCase):
         mock_post.assert_called_once_with('/virtual_machines/12345/validate_backup_credentials', {'guest_username': username, 'guest_password': password},
                                           custom_headers=None)
 
+    @mock.patch.object(Connection, "get")
+    def test_get_metrics(self, mock_get):
+        resource_data = {"metrics": [{"name": "iops",
+                                      "data_points": [{
+                                          "reads": 0,
+                                          "writes": 0,
+                                          "date": "2020-06-22T14:05:00Z"
+                                      }]
+                                      }]
+                         }
+        mock_get.return_value = resource_data
+        vm_data = {'name': 'VM1', 'id': '12345'}
+        vm = self.machines.get_by_data(vm_data)
+        response = vm.get_metrics()
+        self.assertEqual(response, resource_data)
+        mock_get.assert_has_calls([call('/virtual_machines/12345/metrics?range=43200&resolution=MINUTE&time_offset=0')])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Hemant Chaudhari <hchaudhari@hpe.com>

### Description
Add support to get virtual machine metrics

### Issues Resolved
None

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
