### PR TITLE
Add support to update the external store access credential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /datastore/{datastoreId}/standard_hosts <GET>
     - endpoint support for /external_stores <GET>
     - endpoint support for /external_stores <POST>
+    - endpoint support for /external_stores/update_credentials <POST>
     - endpoint support for /hosts/{hostId}/capacity <GET>
     - endpoint support for /hosts/{hostId}/cancel_virtual_controller_shutdown <POST>
     - endpoint support for /hosts/{hostId}/remove_from_federation <POST>    

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -31,6 +31,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |     **External Stores**
 |<sub>/external_stores</sub>                                                                 |GET     |
 |<sub>/external_stores</sub>                                                                 |POST    |
+|<sub>/external_stores/update_credentials</sub>                                              |POST    |
 |     **Hosts**
 |<sub>/hosts</sub>                                                                           |GET     |
 |<sub>/hosts/{hostId}/cancel_virtual_controller_shutdown</sub>                               |POST    |

--- a/examples/external_stores.py
+++ b/examples/external_stores.py
@@ -79,3 +79,7 @@ external_store_obj = external_stores.register_external_store(management_ip, exte
 
 print(f"{external_store_obj}")
 print(f"{pp.pformat(external_store_obj.data)} \n")
+
+print("\n\nupdate external store access credential")
+# We can provide the updated credential to access the external store
+external_stores.update_credentials(external_store_name, username, password)

--- a/simplivity/resources/external_stores.py
+++ b/simplivity/resources/external_stores.py
@@ -111,6 +111,28 @@ class ExternalStores(ResourceBase):
 
         return self.get_by_name(name)
 
+    def update_credentials(self, name, username, password, management_ip=None, timeout=-1):
+        """Update the IP address or credentials that HPE SimpliVity uses to access the external stores
+
+         Args:
+            name: The name of the external_store
+            username: The client name of the external store
+            password: The client password of the external store
+            management_ip: The IP address of the external store
+            timeout: Time out for the request in seconds.
+
+        Returns:
+            object: External store object.
+        """
+
+        resource_uri = "{}/update_credentials".format(URL)
+        data = {'name': name, 'username': username, 'password': password}
+        if management_ip:
+            data['management_ip'] = management_ip
+
+        custom_headers = {'Content-type': 'application/vnd.simplivity.v1.15+json'}
+        self._client.do_post(resource_uri, data, timeout, custom_headers)
+
 
 class ExternalStore(object):
     """Implements features available for a single External store resources."""

--- a/tests/unit/resources/test_external_stores.py
+++ b/tests/unit/resources/test_external_stores.py
@@ -110,6 +110,17 @@ class ExternalStoresTest(unittest.TestCase):
         mock_post.assert_called_once_with(external_stores.URL, data,
                                           custom_headers={'Content-type': 'application/vnd.simplivity.v1.11+json'})
 
+    @mock.patch.object(Connection, "post")
+    def test_update_credential(self, mock_post):
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        self.external_stores.update_credentials('storeonce_cat1', 'Admin',
+                                                'pass12', '127.12.34.12')
+        data = {'name': 'storeonce_cat1', 'username': 'Admin',
+                'password': 'pass12', 'management_ip': '127.12.34.12'}
+
+        mock_post.assert_called_once_with('/external_stores/update_credentials', data,
+                                          custom_headers={'Content-type': 'application/vnd.simplivity.v1.15+json'})
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Hemant Chaudhari <hchaudhari@hpe.com>

### Description
Add support to update the external store access credential

### Issues Resolved
None

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
