### PR TITLE
Add support to get metrics for the cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /hosts/{hostId}/virtual_controller_shutdown_status <GET>
     - endpoint support for /omnistack_clusters/time_zone_list <GET>
     - endpoint support for /omnistack_clusters/{clusterId}/connected_clusters  <GET>
+    - endpoint support for /omnistack_clusters/{clusterId}/metrics  <GET>
     - endpoint support for /omnistack_clusters/{clusterId}/set_time_zone <POST>
     - endpoint support for /omnistack_clusters/{clusterId}/throughput <GET>
     - endpoint support for /policies <POST>

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -43,6 +43,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/omnistack_clusters</sub>                                                              |GET     |
 |<sub>/omnistack_clusters/time_zone_list</sub>                                               |GET     |
 |<sub>/omnistack_clusters/{clusterId}/connected_clusters</sub>                               |GET     |
+|<sub>/omnistack_clusters/{clusterId}/metrics</sub>                                          |GET     |
 |<sub>/omnistack_clusters/{clusterId}/set_time_zone</sub>                                    |POST    |
 |<sub>/omnistack_clusters/{clusterId}/throughput</sub>                                       |GET     |
 |     **Policies**

--- a/examples/omnistack_clusters.py
+++ b/examples/omnistack_clusters.py
@@ -100,3 +100,7 @@ print("\n\nget_throughput")
 cluster1 = clusters.get_by_name(cluster_1_name)
 cluster_throuput = cluster1.get_throughput('', 0, 50)
 print(f"{pp.pformat(cluster_throuput)} \n")
+
+print("\n\nget metrics report for cluster")
+cluster_metrics = cluster1.get_metrics()
+print(f"{pp.pformat(cluster_metrics)} \n")

--- a/simplivity/resources/omnistack_clusters.py
+++ b/simplivity/resources/omnistack_clusters.py
@@ -174,3 +174,20 @@ class OmnistackCluster(object):
         self._client.do_post(method_url, data, timeout)
         self.__refresh()
         return self
+
+    def get_metrics(self, time_offset=0, range=43200, resolution='MINUTE'):
+        """Retrieves throughput, IOPS, and latency data for cluster.
+
+        Args:
+            time_offset: A time offset in seconds (from now) or a datetime,
+                        expressed in ISO-8601 form, based on Coordinated Universal Time (UTC) Default: 0
+            range: A range in seconds (the duration from the specified point in time) Default: 43200
+            resolution: The resolution (SECOND, MINUTE, HOUR, or DAY) Default: MINUTE
+
+        Returns:
+            dict: Dictionary of metrics object.
+        """
+        method_url = "{}/{}/metrics".format(URL, self.data["id"])
+        filters = {'time_offset': time_offset, 'range': range, 'resolution': resolution}
+
+        return self._client.do_get(method_url, filters)

--- a/tests/unit/resources/test_omnistack_clusters.py
+++ b/tests/unit/resources/test_omnistack_clusters.py
@@ -165,6 +165,23 @@ class OmnistackClustersTest(unittest.TestCase):
         data = {'time_zone': 'Africa/Accra'}
         mock_post.assert_called_once_with('/omnistack_clusters/12345/set_time_zone', data, custom_headers=None)
 
+    @mock.patch.object(Connection, "get")
+    def test_get_metrics(self, mock_get):
+        resource_data = {"metrics": [{"name": "iops",
+                                      "data_points": [{
+                                          "reads": 0,
+                                          "writes": 0,
+                                          "date": "2020-06-22T14:05:00Z"
+                                      }]
+                                      }]
+                         }
+        mock_get.return_value = resource_data
+        cluster_data = {'name': 'cluster', 'id': '12345'}
+        cluster = self.clusters.get_by_data(cluster_data)
+        response = cluster.get_metrics()
+        self.assertEqual(response, resource_data)
+        mock_get.assert_has_calls([call('/omnistack_clusters/12345/metrics?range=43200&resolution=MINUTE&time_offset=0')])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Hemant Chaudhari <hchaudhari@hpe.com>

### Description
Add support to get metrics for the cluster

### Issues Resolved
None

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
