### PR TITLE
Add support for backups get virtual disk partition files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /backups/{bkpId}/rename <POST>
     - endpoint support for /backups/{bkpId}/restore <POST>
     - endpoint support for /backups/{bkpId}/virtual_disk_partitions <GET>
+    - endpoint support for /backups/{bkpId}/virtual_disk_partition_files <GET>
     - endpoint support for /cluster_groups <GET>
     - endpoint support for /cluster_groups/{clusterGroupId}/rename <POST>
     - endpoint support for /datastore <POST>

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -17,6 +17,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/backups/{bkpId}/rename</sub>                                                          |POST    |
 |<sub>/backups/{bkpId}/restore</sub>                                                         |POST    |
 |<sub>/backups/{bkpId}/virtual_disk_partitions</sub>                                         |GET     |
+|<sub>/backups/{bkpId}/virtual_disk_partition_files</sub>                                    |GET     |
 |     **Cluster Groups**
 |<sub>/cluster_groups</sub>                                                                  |GET     |
 |<sub>/cluster_groups/{clusterGroupId}/rename</sub>                                          |POST    |

--- a/examples/backups.py
+++ b/examples/backups.py
@@ -173,3 +173,7 @@ backup.delete()
 print("\n\nget virtual disk partitions")
 partition_data = backup_object.get_virtual_disk_partitions(virtual_disk)
 print(f"{pp.pformat(partition_data)}")
+
+print("\n\nget virtual disk partition files")
+partition_data = backup_object.get_virtual_disk_partition_files(virtual_disk, 1, "/")
+print(f"{pp.pformat(partition_data)}")

--- a/simplivity/resources/backups.py
+++ b/simplivity/resources/backups.py
@@ -303,3 +303,21 @@ class Backup(object):
         data = {'virtual_disk': virtual_disk}
 
         return self._client.do_get(resource_uri, data)
+
+    def get_virtual_disk_partition_files(self, virtual_disk, partition_number, file_path):
+        """Retrieves the virtual hard disk files from the backup
+        Args:
+            virtual_disk: The name of the virtual hard disk for the virtual machine.
+            partition_number: The partition number of the virtual disk associated with the backup.
+            file_path: The path in the partition that has the file information you want. e.g. for root directory use "/".
+
+        Returns:
+            dict: Returns dictionary containing virtual hard disk files from the backup.
+        """
+
+        resource_uri = "{}/{}/virtual_disk_partition_files".format(URL, self.data["id"])
+        data = {'virtual_disk': virtual_disk,
+                'partition_number': partition_number,
+                'file_path': file_path}
+
+        return self._client.do_get(resource_uri, data)

--- a/tests/unit/resources/test_backups.py
+++ b/tests/unit/resources/test_backups.py
@@ -385,6 +385,26 @@ class BackupTest(unittest.TestCase):
         self.assertEqual(partition_data, resource_data)
         mock_get.assert_has_calls([call('/backups/12345/virtual_disk_partitions?virtual_disk=tinyvm32_ATF_0.vmdk')])
 
+    @mock.patch.object(Connection, "get")
+    def test_get_virtual_disk_partition_files(self, mock_get):
+        resource_data = {"virtual_disk_partition_files": [{
+                         "name": "grub",
+                         "directory": True,
+                         "symbolic_link": False,
+                         "size": 0,
+                         "last_modified": "2013-01-18T14:51:43Z",
+                         "file_level_restore_available": True
+                         }]}
+        mock_get.return_value = resource_data
+        backup_data = {'name': 'name1', 'id': '12345'}
+        backup = self.backups.get_by_data(backup_data)
+        virtual_disk = "tinyvm32_ATF_0.vmdk"
+        partition_number = 1
+        file_path = "/"
+        partition_data = backup.get_virtual_disk_partition_files(virtual_disk, partition_number, file_path)
+        self.assertEqual(partition_data, resource_data)
+        mock_get.assert_has_calls([call('/backups/12345/virtual_disk_partition_files?file_path=%2F&partition_number=1&virtual_disk=tinyvm32_ATF_0.vmdk')])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Description
Add support for backups get virtual disk partition files

### Issues Resolved
None

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
